### PR TITLE
v2.4.24 -- per-page <title> via useDocumentTitle hook (closes a11y-11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [2.4.24] - 2026-04-29
+
+Closes the **first deferred item from the v2.4.23 a11y audit** — per-page `<title>` (a11y-11 / WCAG SC 2.4.2 Page Titled).
+
+### Fixed — every page now has its own `<title>`
+
+Pre-v2.4.24 every browser tab said "NIS2 Platform" — the only metadata exported was the root layout default. That fails three real workflows:
+
+1. **Bookmarking**: a user bookmarking `/dashboard/findings` got a "NIS2 Platform" entry, indistinguishable from a bookmark of `/dashboard/scans` or `/login`.
+2. **Tab management**: power users with 5–10 tabs across the platform couldn't tell tabs apart at a glance — every tab title and favicon was identical.
+3. **Screen-reader announcement (WCAG SC 2.4.2)**: SR users hear the page title when a page loads. With every page sharing one title, the announcement carried zero information about *where* they had landed.
+
+### How it works
+
+A new `useDocumentTitle(title)` hook (`src/hooks/use-document-title.ts`) mutates `document.title` in a `useEffect` and restores the previous title on unmount. Every page-level component now calls it with its localised `t("title")` from the existing `useTranslations` namespace — so an Italian user on `/dashboard/scans` sees "Scansioni — NIS2 Platform" in the browser tab.
+
+**Why a hook and not `generateMetadata`**: the App Router exposes per-route metadata only from server components. The dashboard pages are all `"use client"` because they pull from TanStack Query / Zustand stores that need browser-only APIs. Splitting each route into a server-shell + client-body is a 22-route refactor for no incremental benefit — `useEffect` is the idiomatic React pattern for this case.
+
+### Coverage
+
+22 page-level components wired in this patch:
+
+- **Auth**: `/login`, `/register`, `/forgot-password`, `/reset-password`
+- **Dashboard root**: `/dashboard`
+- **Dashboard primary**: `/dashboard/scans`, `/dashboard/scans/[id]` (uses scan name when loaded), `/dashboard/scans/new`, `/dashboard/scans/schedules`, `/dashboard/scans/[id]/compare`, `/dashboard/findings`, `/dashboard/assets`, `/dashboard/compliance`, `/dashboard/reports`
+- **Settings**: `/dashboard/settings` (root index), `/dashboard/settings/profile`, `/dashboard/settings/organization`, `/dashboard/settings/team`, `/dashboard/settings/api-keys`, `/dashboard/settings/notifications`, `/dashboard/settings/audit-log`, `/dashboard/settings/scan-defaults`
+
+Each title is fully localised across all 5 locales (en / it / fr / de / es) — no new translation keys were added; the patch reuses the existing `t("title")` strings already maintained by every namespace.
+
+### Verified
+
+- `npm run build` green — 24/24 pages compile, no new TS errors.
+- Manual smoke: navigating between /dashboard, /dashboard/scans, /dashboard/findings, /login each updates the browser tab title to the localised page name + " — NIS2 Platform" suffix.
+- /dashboard/scans/[id] picks up the actual scan name once the scan hydrates (`scan?.name || ts("title")` fallback so the tab isn't blank during the loading window).
+
+### Deferred to v2.4.25
+
+- Mobile sidebar focus trap (Sheet/Drawer refactor).
+- Recharts colour palette tuning for deuteranopia (a11y-21).
+
 ## [2.4.23] - 2026-04-28
 
 Dedicated **WCAG 2.1 Level AA accessibility audit** of the entire frontend. A draconian sweep across every authenticated screen identified 30 a11y gaps — the patch closes the highest-impact 20 of them in one pass, covering keyboard users, screen-reader users, and users with colour-vision deficiencies.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nis2-public-docs",
-  "version": "2.4.23",
+  "version": "2.4.24",
   "private": true,
   "description": "VitePress documentation build for the NIS2 Continuous Posture Management Platform.",
   "scripts": {

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -21,7 +21,7 @@ from app.routers.auth import limiter
 
 logger = logging.getLogger(__name__)
 
-API_VERSION = "2.4.23"
+API_VERSION = "2.4.24"
 
 # Defence in depth: applied unconditionally at the API.
 # Caddy adds equivalent headers at the edge in production deployments.

--- a/packages/api/app/mcp_server.py
+++ b/packages/api/app/mcp_server.py
@@ -235,7 +235,7 @@ def run_mcp_stdio():
                             "capabilities": {"tools": {}},
                             "serverInfo": {
                                 "name": "nis2-compliance",
-                                "version": "2.4.23",
+                                "version": "2.4.24",
                             },
                         },
                     }

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nis2-api"
-version = "2.4.23"
+version = "2.4.24"
 description = "NIS2 Compliance Platform API"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/api/tests/test_api.py
+++ b/packages/api/tests/test_api.py
@@ -264,7 +264,7 @@ class TestOpenAPI:
         assert resp.status_code == 200
         schema = resp.json()
         assert schema["info"]["title"] == "NIS2 Compliance Platform API"
-        assert schema["info"]["version"] == "2.4.23"
+        assert schema["info"]["version"] == "2.4.24"
 
     def test_all_router_tags_present(self, client):
         resp = client.get("/openapi.json")

--- a/packages/scanner/pyproject.toml
+++ b/packages/scanner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nis2scan"
-version = "2.4.23"
+version = "2.4.24"
 description = "NIS2 Directive compliance scanner engine"
 requires-python = ">=3.10"
 dependencies = [

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nis2/web",
-  "version": "2.4.23",
+  "version": "2.4.24",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packages/web/src/app/(auth)/forgot-password/page.tsx
+++ b/packages/web/src/app/(auth)/forgot-password/page.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { api } from "@/lib/api-client"
 import { Logo } from "@/components/brand/logo"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 // Audit B05 — entry point of the password-reset flow.
 //
@@ -38,6 +39,8 @@ export default function ForgotPasswordPage() {
   const [loading, setLoading] = useState(false)
   const [submitted, setSubmitted] = useState(false)
   const [submittedEmail, setSubmittedEmail] = useState("")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("forgotPasswordPage.title"))
 
   const {
     register,

--- a/packages/web/src/app/(auth)/login/page.tsx
+++ b/packages/web/src/app/(auth)/login/page.tsx
@@ -19,6 +19,7 @@ import { Label } from "@/components/ui/label"
 import { api } from "@/lib/api-client"
 import { useAuthStore } from "@/stores/auth-store"
 import { Logo } from "@/components/brand/logo"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 // Schema messages stay English here — zod resolves them at form-init time,
 // before useTranslations is available. The useTranslations layer below
@@ -43,6 +44,8 @@ export default function LoginPage() {
   const sessionExpired = searchParams?.get("session") === "expired"
   const setAuth = useAuthStore((s) => s.setAuth)
   const [loading, setLoading] = useState(false)
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("auth.signIn"))
 
   const {
     register,

--- a/packages/web/src/app/(auth)/register/page.tsx
+++ b/packages/web/src/app/(auth)/register/page.tsx
@@ -19,6 +19,7 @@ import { Label } from "@/components/ui/label"
 import { api } from "@/lib/api-client"
 import { useAuthStore } from "@/stores/auth-store"
 import { Logo } from "@/components/brand/logo"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 // Like login: zod messages are i18n keys resolved via t(...) at render.
 const registerSchema = z.object({
@@ -35,6 +36,8 @@ export default function RegisterPage() {
   const router = useRouter()
   const setAuth = useAuthStore((s) => s.setAuth)
   const [loading, setLoading] = useState(false)
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("auth.register"))
 
   const {
     register,

--- a/packages/web/src/app/(auth)/reset-password/page.tsx
+++ b/packages/web/src/app/(auth)/reset-password/page.tsx
@@ -18,6 +18,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { api } from "@/lib/api-client"
 import { Logo } from "@/components/brand/logo"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 // Audit B05 — completes the reset flow. Token comes from the URL
 // query string (?token=...) of the link in the email.
@@ -47,6 +48,8 @@ function ResetPasswordInner() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const token = searchParams?.get("token") || ""
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("resetPasswordPage.title"))
 
   const [loading, setLoading] = useState(false)
   const [done, setDone] = useState(false)

--- a/packages/web/src/app/dashboard/assets/page.tsx
+++ b/packages/web/src/app/dashboard/assets/page.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/select"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { useAssets, useCreateAsset, useDeleteAsset, useUpdateAsset } from "@/hooks/use-assets"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 const assetSchema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -42,6 +43,8 @@ const typeColors: Record<string, string> = {
 export default function AssetsPage() {
   const t = useTranslations("assets")
   const tc = useTranslations("common")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("title"))
   const [dialogOpen, setDialogOpen] = useState(false)
   const [deleteId, setDeleteId] = useState<string | null>(null)
   // editingAsset null = create mode; non-null = edit mode pre-populating

--- a/packages/web/src/app/dashboard/compliance/page.tsx
+++ b/packages/web/src/app/dashboard/compliance/page.tsx
@@ -11,6 +11,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { useScans } from "@/hooks/use-scans"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 // NIS2 Art. 21(2) subsections — Italian text is the canonical legal
 // reference under D.Lgs 138/2024 and stays as-is regardless of locale.
@@ -40,6 +41,8 @@ function mapStatus(matrixStatus: string): "pass" | "partial" | "fail" | "manual"
 
 export default function CompliancePage() {
   const t = useTranslations("compliancePage")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("title"))
   const { data: scansData, isLoading } = useScans()
   // Status labels are translated; icons + colours stay constant. The
   // tuple shape mirrors the previous `statusConfig` object.

--- a/packages/web/src/app/dashboard/findings/page.tsx
+++ b/packages/web/src/app/dashboard/findings/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/select"
 import { useFindings, useUpdateFinding } from "@/hooks/use-findings"
 import { useDebounce } from "@/hooks/use-debounce"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 import { cn } from "@/lib/utils"
 
 // v2.4.5 killed the /dashboard mock data; the equivalent `sampleFindings`
@@ -45,6 +46,8 @@ export default function FindingsPage() {
   // v2.4.23 audit a11y namespace for accessibility-only strings
   // (filter Select labels, checkbox labels, expand/collapse buttons).
   const ta = useTranslations("a11y")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("title"))
   const [severityFilter, setSeverityFilter] = useState("all")
   const [statusFilter, setStatusFilter] = useState("all")
   const [categoryFilter, setCategoryFilter] = useState("all")

--- a/packages/web/src/app/dashboard/page.tsx
+++ b/packages/web/src/app/dashboard/page.tsx
@@ -14,6 +14,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { useScans } from "@/hooks/use-scans"
 import { useFindingStats } from "@/hooks/use-findings"
 import { useAssets } from "@/hooks/use-assets"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 import { cn } from "@/lib/utils"
 
 // Lazy load Recharts (400KB+) — only loads when charts are visible
@@ -86,6 +87,8 @@ export default function DashboardPage() {
   // so dates render in the user's active locale (IT / FR / DE / ES)
   // rather than always en-US.
   const formatDate = useFormatDate()
+  // v2.4.24 audit a11y-11: per-page <title> via document.title.
+  useDocumentTitle(t("title"))
 
   const { data: scansData, isLoading: scansLoading } = useScans()
   const { data: statsData } = useFindingStats()

--- a/packages/web/src/app/dashboard/reports/page.tsx
+++ b/packages/web/src/app/dashboard/reports/page.tsx
@@ -20,6 +20,7 @@ import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table"
 import { useScans } from "@/hooks/use-scans"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 import { api } from "@/lib/api-client"
 import { cn } from "@/lib/utils"
 
@@ -51,6 +52,8 @@ const POLL_TIMEOUT_MS = 5 * 60 * 1000  // 5 minutes — beyond this, surface an 
 
 export default function ReportsPage() {
   const t = useTranslations("reports")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("title"))
   // Re-use the `scans` namespace's pagination strings (previous /
   // page / next) — same widget renders on both pages, no need to
   // mint separate keys.

--- a/packages/web/src/app/dashboard/scans/[id]/compare/page.tsx
+++ b/packages/web/src/app/dashboard/scans/[id]/compare/page.tsx
@@ -17,6 +17,7 @@ import { Badge } from "@/components/ui/badge"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { api } from "@/lib/api-client"
 import { useScans } from "@/hooks/use-scans"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 const severityColors: Record<string, string> = {
   CRITICAL: "destructive",
@@ -32,6 +33,8 @@ const severityColors: Record<string, string> = {
 export default function ScanComparePage() {
   const t = useTranslations("scansComparePage")
   const tf = useTranslations("findings")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("title"))
   const params = useParams()
   const scanId = params.id as string
   const { data: scansData } = useScans()

--- a/packages/web/src/app/dashboard/scans/[id]/page.tsx
+++ b/packages/web/src/app/dashboard/scans/[id]/page.tsx
@@ -14,6 +14,7 @@ import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { useScan, useScanResults, useScanFindings } from "@/hooks/use-scans"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 import { cn } from "@/lib/utils"
 
 const severityVariant: Record<string, "critical" | "high" | "medium" | "low" | "info"> = {
@@ -58,6 +59,12 @@ export default function ScanDetailPage({ params }: { params: Promise<{ id: strin
   const { data: scan, isLoading } = useScan(id)
   const { data: resultsData } = useScanResults(id)
   const { data: findingsData } = useScanFindings(id)
+
+  // v2.4.24 audit a11y-11: per-page <title>. Falls back to the
+  // namespace name while the scan is loading; once the scan
+  // hydrates the tab shows the actual scan name so the user can
+  // tell two scan-detail tabs apart.
+  useDocumentTitle(scan?.name || ts("title"))
 
   const results = resultsData?.items || []
   const findings = findingsData?.items || []

--- a/packages/web/src/app/dashboard/scans/new/page.tsx
+++ b/packages/web/src/app/dashboard/scans/new/page.tsx
@@ -18,6 +18,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useCreateScan } from "@/hooks/use-scans"
 import { useAssets } from "@/hooks/use-assets"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 // Field names MUST match the backend schema (packages/api/app/schemas/scan.py:ScanCreate
 // + packages/api/app/routers/scans.py create_scan default features). Pydantic
@@ -60,6 +61,8 @@ type ScanForm = z.infer<typeof scanSchema>
 export default function NewScanPage() {
   const t = useTranslations("scansNewPage")
   const tc = useTranslations("common")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("title"))
   const router = useRouter()
   const createScan = useCreateScan()
   const { data: assetsData } = useAssets()

--- a/packages/web/src/app/dashboard/scans/page.tsx
+++ b/packages/web/src/app/dashboard/scans/page.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { useScans } from "@/hooks/use-scans"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 import { cn } from "@/lib/utils"
 import { useState } from "react"
 
@@ -39,6 +40,8 @@ export default function ScansPage() {
   const { data, isLoading } = useScans(page)
   const t = useTranslations("scans")
   const formatDate = useFormatDate()
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("title"))
   const scans = data?.items || []
   const total = data?.total || 0
 

--- a/packages/web/src/app/dashboard/scans/schedules/page.tsx
+++ b/packages/web/src/app/dashboard/scans/schedules/page.tsx
@@ -22,6 +22,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { api } from "@/lib/api-client"
 import { useAuthStore } from "@/stores/auth-store"
 import { useAssets } from "@/hooks/use-assets"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 import { useFormatDate } from "@/lib/dates"
 
 // v2.4.17 audit S-DRA-03: cron validation. Previously the schema
@@ -60,6 +61,8 @@ const cronPresetKeys = [
 export default function SchedulesPage() {
   const t = useTranslations("schedulesPage")
   const tc = useTranslations("common")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("title"))
   const formatDate = useFormatDate()
   const user = useAuthStore((s) => s.user)
   const { data: assetsData } = useAssets()

--- a/packages/web/src/app/dashboard/settings/api-keys/page.tsx
+++ b/packages/web/src/app/dashboard/settings/api-keys/page.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/components/ui/dialog"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { useApiKeys, useCreateApiKey, useRevokeApiKey } from "@/hooks/use-api-keys"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 const createKeySchema = z.object({
   name: z.string().min(1, "apiKeysPage.nameRequired").max(256),
@@ -38,6 +39,8 @@ type CreateKeyForm = z.infer<typeof createKeySchema>
 export default function ApiKeysPage() {
   const t = useTranslations("apiKeysPage")
   const tc = useTranslations("common")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("title"))
   const formatDate = useFormatDate()
   const { data: keysData, isLoading } = useApiKeys()
   const createKey = useCreateApiKey()

--- a/packages/web/src/app/dashboard/settings/audit-log/page.tsx
+++ b/packages/web/src/app/dashboard/settings/audit-log/page.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { useAuditLogs } from "@/hooks/use-audit-logs"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 // Severity-ish colour buckets for the action namespace prefix.
 // Doesn't try to be exhaustive — anything unknown falls back to muted.
@@ -27,6 +28,8 @@ const actionColors: Record<string, string> = {
 export default function AuditLogPage() {
   const t = useTranslations("auditLogPage")
   const tc = useTranslations("common")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("title"))
   // Pagination strings (previous / next / page) live in the `scans`
   // namespace — same widget rides on /scans, /reports, here, and
   // every other paginated table. Reusing keeps the translations in

--- a/packages/web/src/app/dashboard/settings/notifications/page.tsx
+++ b/packages/web/src/app/dashboard/settings/notifications/page.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 interface Channel {
   id: string
@@ -36,6 +37,8 @@ const eventValues = [
 export default function NotificationsPage() {
   const t = useTranslations("notificationsPage")
   const tc = useTranslations("common")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("title"))
   const [channels, setChannels] = useState<Channel[]>([])
   const [showAdd, setShowAdd] = useState(false)
   const [newType, setNewType] = useState<"email" | "webhook">("email")

--- a/packages/web/src/app/dashboard/settings/organization/page.tsx
+++ b/packages/web/src/app/dashboard/settings/organization/page.tsx
@@ -17,6 +17,7 @@ import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
 import { api } from "@/lib/api-client"
 import { useAuthStore } from "@/stores/auth-store"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 // The error message is an i18n KEY resolved via `t(error.message)` at
 // render — same pattern as login / register (zod is initialised before
@@ -31,6 +32,8 @@ type OrgForm = z.infer<typeof orgSchema>
 
 export default function OrganizationSettingsPage() {
   const t = useTranslations("organizationPage")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("title"))
   const orgId = useAuthStore((s) => s.orgId)
   const [loading, setLoading] = useState(false)
   const [org, setOrg] = useState<any>(null)

--- a/packages/web/src/app/dashboard/settings/page.tsx
+++ b/packages/web/src/app/dashboard/settings/page.tsx
@@ -5,7 +5,9 @@
 
 import Link from "next/link"
 import { Building2, UserCog, Radar, Users, Key, Bell, ScrollText, ChevronRight } from "lucide-react"
+import { useTranslations } from "next-intl"
 import { Card, CardContent } from "@/components/ui/card"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 const settingsLinks = [
   {
@@ -53,10 +55,13 @@ const settingsLinks = [
 ]
 
 export default function SettingsPage() {
+  const tc = useTranslations("common")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(tc("settings"))
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-3xl font-bold tracking-tight">Settings</h1>
+        <h1 className="text-3xl font-bold tracking-tight">{tc("settings")}</h1>
         <p className="text-muted-foreground">Manage your organization and account settings</p>
       </div>
 

--- a/packages/web/src/app/dashboard/settings/profile/page.tsx
+++ b/packages/web/src/app/dashboard/settings/profile/page.tsx
@@ -17,6 +17,7 @@ import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
 import { api } from "@/lib/api-client"
 import { useAuthStore } from "@/stores/auth-store"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 const profileSchema = z.object({
   full_name: z.string().min(1, "Name is required").max(256),
@@ -52,6 +53,8 @@ const locales = [
 
 export default function ProfileSettingsPage() {
   const t = useTranslations("profilePage")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("title"))
   // Top-level translator so zod messages like "auth.passwordMin8" resolve
   // across namespaces. The form-validation errors are stored as i18n
   // *keys* (not messages) — see passwordSchema above.

--- a/packages/web/src/app/dashboard/settings/scan-defaults/page.tsx
+++ b/packages/web/src/app/dashboard/settings/scan-defaults/page.tsx
@@ -17,6 +17,7 @@ import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
 import { api } from "@/lib/api-client"
 import { useAuthStore } from "@/stores/auth-store"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 const scanDefaultsSchema = z.object({
   scan_timeout: z.coerce.number().min(1).max(120),
@@ -42,6 +43,8 @@ const defaults: ScanDefaultsForm = {
 
 export default function ScanDefaultsPage() {
   const t = useTranslations("scanDefaultsPage")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("title"))
   const orgId = useAuthStore((s) => s.orgId)
   const [loading, setLoading] = useState(false)
 

--- a/packages/web/src/app/dashboard/settings/team/page.tsx
+++ b/packages/web/src/app/dashboard/settings/team/page.tsx
@@ -49,6 +49,7 @@ import {
   useRemoveMember,
 } from "@/hooks/use-members"
 import { useAuthStore } from "@/stores/auth-store"
+import { useDocumentTitle } from "@/hooks/use-document-title"
 
 // Role enum aligned with the backend's Pydantic Literal in
 // schemas/organization.py: admin / auditor / viewer.
@@ -72,6 +73,8 @@ const roleColors: Record<string, string> = {
 export default function TeamPage() {
   const t = useTranslations("teamPage")
   const tc = useTranslations("common")
+  // v2.4.24 audit a11y-11: per-page <title>.
+  useDocumentTitle(t("title"))
   const formatDate = useFormatDate()
   const currentUser = useAuthStore((s) => s.user)
 

--- a/packages/web/src/hooks/use-document-title.ts
+++ b/packages/web/src/hooks/use-document-title.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2024-2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+// NIS2 Compliance Platform — https://github.com/fabriziosalmi/nis2-public
+"use client"
+
+import { useEffect } from "react"
+
+/**
+ * v2.4.24 audit a11y-11 (WCAG SC 2.4.2 Page Titled): every web page
+ * needs a unique, descriptive `<title>` so screen-reader users hear
+ * where they are when a page loads, browser tabs are distinguishable
+ * at a glance, and bookmarks / browser history aren't all stamped
+ * with the same generic "NIS2 Platform" string.
+ *
+ * The App Router exposes per-route metadata only from server
+ * components (`export const metadata` / `generateMetadata`). The
+ * dashboard pages are all client components ("use client") because
+ * they pull from TanStack Query / Zustand stores that need browser-
+ * only APIs. Splitting each route into a server-component shell +
+ * client-component body is a 22-route refactor; instead this hook
+ * mutates `document.title` directly in a useEffect, which is the
+ * idiomatic React-in-the-App-Router pattern for this case.
+ *
+ * The previous `<title>` is restored on unmount so navigating back
+ * to a page without the hook (or to the implicit "NIS2 Platform"
+ * default from the root layout) doesn't leave the previous page's
+ * title stuck in the tab.
+ *
+ * @param title  page-specific portion of the title — already
+ *               localised by the caller via `useTranslations`
+ */
+export function useDocumentTitle(title: string) {
+  useEffect(() => {
+    if (!title) return
+    const previous = document.title
+    document.title = `${title} — NIS2 Platform`
+    return () => {
+      document.title = previous
+    }
+  }, [title])
+}


### PR DESCRIPTION
## Summary

Closes the first deferred item from the v2.4.23 a11y audit — **per-page `<title>`** (a11y-11 / WCAG SC 2.4.2 Page Titled). Pre-2.4.24 every tab said "NIS2 Platform" — bookmarks were indistinguishable, tab management was painful, and SR users heard zero context on page load.

- New \`useDocumentTitle(title)\` hook in \`src/hooks/use-document-title.ts\` mutates \`document.title\` in \`useEffect\` and restores on unmount.
- Wired into **22 page-level components** (auth + dashboard + all 7 settings subpages).
- Fully localised via existing \`t("title")\` strings — zero new translation keys.
- \`/dashboard/scans/[id]\` picks up the actual scan name once the scan hydrates.

## Why useEffect and not generateMetadata

Every page is \`"use client"\` (TanStack Query / Zustand stores need browser APIs), and App Router metadata is server-only. Splitting 22 routes into server-shell + client-body is a refactor for no incremental benefit; \`useEffect\` is the idiomatic React pattern for this case.

## Test plan

- [x] \`npm run build\` green (24/24 pages compile, no new TS errors)
- [x] Manual smoke: navigating between routes updates the tab title

🤖 Generated with [Claude Code](https://claude.com/claude-code)