### PR TITLE
v2.4.26 -- API audit triage: cron validation + API key scope vocabulary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## [2.4.26] - 2026-04-29
+
+API surface audit triage — closes the only **real** BLOCKER from the v2.4.25 audit pass plus one verified SERIOUS gap. The other "blockers" the audit agent flagged turned out to be false positives on close reading; this CHANGELOG documents what was actually broken vs. what was misread, so the audit trail is honest.
+
+### Audit transparency: 2 of 3 reported blockers were false positives
+
+The audit agent that ran after v2.4.25 reported 3 BLOCKER-class issues. Verifying each against the source:
+
+| # | Reported issue | Verdict |
+|---|---|---|
+| 1 | API key expiration race in `dependencies.py:297-303` — "request A proceeds with stale state" | **False positive.** The expiry check (`expires_at <= now`) is inline in the same request and raises 401 unconditionally if the key is expired. There is no window where a request "proceeds with stale state" — both concurrent requests on an expired key get rejected. The `is_active=False` flush is best-effort cleanup; even if it's rolled back, the next request still rejects via the inline expiry check. |
+| 2 | Missing `await db.commit()` after `db.delete()` across multiple routers | **False positive.** `get_db` is a context-manager dependency in `app/database.py:78-107` that calls `await session.commit()` at request close (after `yield session` returns), and rolls back on exception. The routers' `db.delete() + db.flush()` pattern is correct — flush sends the DELETE to the connection so subsequent queries in the same request see it gone, and the actual COMMIT is at the dependency boundary. The agent missed `get_db`. |
+| 3 | Cron expression validation no-op in `schedules.py:79-81` — accepts `"99 99 99 99 99"` | **REAL.** The route only checked field count, not field values. Bad input was accepted and the schedule silently never fired (the parser in `_should_run` swallows exceptions and returns False). Fixed in this patch. |
+
+Only #3 was a real bug. The agent's report on the other two was based on reading the route files in isolation without tracing the request lifecycle through the dependencies and middleware. The CHANGELOG records this so a future reader doesn't think a phantom security bug existed and was silently dropped.
+
+### Fixed — Cron expression validation (was BLOCKER #3)
+
+Pre-2.4.26 `POST /api/v1/schedules` only checked that `cron_expression` had 5 whitespace-separated fields. Strings like `"99 99 99 99 99"`, `"a b c d e"`, or `"@daily"` were accepted, persisted, and rendered in the UI as valid schedules — but never fired, because `app.tasks.scan_tasks._should_run` silently swallows parse exceptions and returns False. Particularly painful "looks valid, doesn't work" failure mode.
+
+**Fix**: new `app/utils/cron.py` with a `validate_cron(expr: str) -> None` function (raises `CronValidationError`, a `ValueError` subclass). Wired into `create_schedule` AND `update_schedule` (a PATCH could previously clobber a working schedule with a parse-fail string). The validator's accepted grammar is exactly the subset that `_should_run` understands — single source of truth, no acceptance/execution drift.
+
+**Accepted forms per field**: `*`, `N`, `N-M` (range), `N,M,K` (list), `*/S`, `N-M/S` (step). Field ranges enforced: minute 0-59, hour 0-23, day-of-month 1-31, month 1-12, day-of-week 0-7. Vixie keywords (`@daily`, `@hourly`, `@reboot`) and day names (`MON`, `TUE`) are explicitly rejected — silent acceptance + runtime parse failure is the exact mode this patch closes.
+
+**Tests**: 47 unit tests in `tests/test_cron_validator.py` covering accepted forms, field-count errors, range checks, range-form (inverted ranges, endpoint-at-boundary), step-form (zero/negative/empty), list-form (empty elements, out-of-range elements), and the rejection of Vixie keywords. The agent-flagged smoking gun (`"99 99 99 99 99"`) has its own pinned test.
+
+### Fixed — API key scope validation (verified SERIOUS, not BLOCKER)
+
+The `POST /api/v1/api-keys` endpoint stored `scopes` as an arbitrary list of strings without validation against any canonical vocabulary. `["yolo", "", "scan:read"]` was accepted, persisted, and returned to the UI — implying enforcement that didn't exist (no code anywhere reads `api_key.scopes` to authorise routes; that's a separate, larger behavioural change tracked for a follow-up).
+
+**Fix**: `app/routers/api_keys.py` now defines `VALID_API_KEY_SCOPES` (frozenset of 8 `<resource>:<verb>` strings) and a `_validate_scopes` helper that rejects unknown scopes, empty / whitespace-only strings, empty lists, duplicates, and non-string elements with HTTP 400. The error message lists the allowed scopes so the UI can show a hint without an extra round-trip.
+
+**Tests**: 15 unit tests in `tests/test_api_key_scopes.py` pinning every accepted form, every rejection class, and the vocabulary shape itself (so adding a scope is a deliberate two-line change to api_keys.py + the test, never an accident).
+
+### Verified
+
+- 62 new unit tests, all green (47 cron + 15 scope).
+- Existing standalone tests still pass — no regressions.
+- Local: `ENVIRONMENT=development pytest tests/test_target_validator.py tests/test_report_i18n.py tests/test_cron_validator.py tests/test_api_key_scopes.py` → **126 passed**.
+
+### Deferred to v2.4.27+
+
+- **Route-level enforcement of API key scopes** — currently scopes are validated at create/update time and stored, but no auth dependency reads them. Closing this requires deciding the per-route mapping (`/scans/*` → `scan:read`/`scan:write`, etc.) and is a behavioural change that wants its own patch with a clear migration story for existing keys.
+- **Recharts colour palette tuning for deuteranopia (a11y-21)** — still a non-issue: dashboard charts use a single dark-blue series. Will revisit if multi-series charts ship.
+
 ## [2.4.25] - 2026-04-29
 
 Closes the **second deferred item from the v2.4.23 a11y audit** — mobile sidebar focus trap (WCAG SC 2.4.3 Focus Order + 2.1.2 No Keyboard Trap).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nis2-public-docs",
-  "version": "2.4.25",
+  "version": "2.4.26",
   "private": true,
   "description": "VitePress documentation build for the NIS2 Continuous Posture Management Platform.",
   "scripts": {

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -21,7 +21,7 @@ from app.routers.auth import limiter
 
 logger = logging.getLogger(__name__)
 
-API_VERSION = "2.4.25"
+API_VERSION = "2.4.26"
 
 # Defence in depth: applied unconditionally at the API.
 # Caddy adds equivalent headers at the edge in production deployments.

--- a/packages/api/app/mcp_server.py
+++ b/packages/api/app/mcp_server.py
@@ -235,7 +235,7 @@ def run_mcp_stdio():
                             "capabilities": {"tools": {}},
                             "serverInfo": {
                                 "name": "nis2-compliance",
-                                "version": "2.4.25",
+                                "version": "2.4.26",
                             },
                         },
                     }

--- a/packages/api/app/routers/api_keys.py
+++ b/packages/api/app/routers/api_keys.py
@@ -27,6 +27,77 @@ from app.models.user import User
 router = APIRouter(prefix="/api-keys", tags=["api-keys"])
 
 
+# v2.4.26 audit: canonical scope vocabulary.
+#
+# Pre-2.4.26 the API accepted any list of strings as `scopes` —
+# `["yolo", "", "scan:read"]` was a valid request. The UI then showed
+# the bogus scope to the user, who reasonably assumed the platform
+# enforced it. The first half of the gap (validation at create time)
+# is closed in this patch; route-level enforcement of these scopes is
+# a separate, larger behavioral change tracked for a follow-up.
+#
+# The vocabulary mirrors the implicit shape the project already uses
+# in `ApiKeyCreate.default` and the audit_log details — `<resource>:<verb>`
+# where verb is `read` or `write`. Adding a scope here is a one-line
+# change and ALWAYS additive (removing one would break existing keys).
+VALID_API_KEY_SCOPES: frozenset[str] = frozenset({
+    "scan:read",
+    "scan:write",
+    "asset:read",
+    "asset:write",
+    "finding:read",
+    "finding:write",
+    "report:read",
+    "report:write",
+})
+
+
+def _validate_scopes(scopes: Optional[list[str]]) -> list[str]:
+    """Raise HTTPException(400) on any unknown / empty / duplicate scope.
+
+    Returns the canonical list (deduplicated, order-preserved) on success.
+    None is treated as 'no override' — the schema default is applied
+    elsewhere; callers that pass None get None back.
+    """
+    if scopes is None:
+        return None  # type: ignore[return-value]
+    if not isinstance(scopes, list):
+        raise HTTPException(status_code=400, detail="scopes must be a list of strings")
+    if not scopes:
+        raise HTTPException(
+            status_code=400,
+            detail="scopes must not be empty (omit the field to use the default set)",
+        )
+    seen: set[str] = set()
+    cleaned: list[str] = []
+    for s in scopes:
+        if not isinstance(s, str) or not s.strip():
+            raise HTTPException(
+                status_code=400,
+                detail="scopes contains an empty or non-string value",
+            )
+        s = s.strip()
+        if s not in VALID_API_KEY_SCOPES:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"unknown scope '{s}'. Allowed: "
+                    f"{', '.join(sorted(VALID_API_KEY_SCOPES))}"
+                ),
+            )
+        if s in seen:
+            # A duplicate is almost certainly user error (UI bug or
+            # copy/paste); reject rather than silently dedupe so the
+            # caller knows.
+            raise HTTPException(
+                status_code=400,
+                detail=f"duplicate scope '{s}'",
+            )
+        seen.add(s)
+        cleaned.append(s)
+    return cleaned
+
+
 # --- Schemas ---
 
 class ApiKeyCreate(BaseModel):
@@ -92,6 +163,11 @@ async def create_api_key(
 ) -> ApiKeyCreated:
     user, membership = current_org
 
+    # v2.4.26 audit: validate scopes against the canonical vocabulary.
+    # On 400 the route returns before any DB write, so a bad request
+    # leaves no orphan key row.
+    cleaned_scopes = _validate_scopes(payload.scopes)
+
     # Generate key: nis2_<40 random chars>
     raw_key = f"nis2_{secrets.token_urlsafe(30)}"
     key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
@@ -103,7 +179,7 @@ async def create_api_key(
         name=payload.name,
         key_hash=key_hash,
         key_prefix=key_prefix,
-        scopes=payload.scopes,
+        scopes=cleaned_scopes,
         is_active=True,
     )
     db.add(api_key)
@@ -119,7 +195,7 @@ async def create_api_key(
         action="api_key.created",
         resource_type="api_key",
         resource_id=str(api_key.id),
-        details={"name": payload.name, "prefix": key_prefix, "scopes": payload.scopes},
+        details={"name": payload.name, "prefix": key_prefix, "scopes": cleaned_scopes},
     )
 
     # Pydantic v2 doesn't accept `update=` on `model_validate`. Build the

--- a/packages/api/app/routers/schedules.py
+++ b/packages/api/app/routers/schedules.py
@@ -15,6 +15,7 @@ from app.dependencies import get_current_org
 from app.models.membership import Membership
 from app.models.scan_schedule import ScanSchedule
 from app.models.user import User
+from app.utils.cron import CronValidationError, validate_cron
 
 
 class ScheduleCreate(BaseModel):
@@ -75,10 +76,19 @@ async def create_schedule(
     if membership.role not in ("admin", "auditor"):
         raise HTTPException(status_code=403, detail="Insufficient permissions")
 
-    # Validate cron expression
-    parts = payload.cron_expression.strip().split()
-    if len(parts) != 5:
-        raise HTTPException(status_code=400, detail="Invalid cron expression. Must have 5 fields: minute hour day month weekday")
+    # v2.4.26 audit: validate the full cron expression (not just the
+    # field count). Pre-2.4.26 the API accepted "99 99 99 99 99" and
+    # the schedule silently never fired because the parser in
+    # scan_tasks._should_run swallows exceptions. Now bad input is
+    # rejected at create time with a message pointing at the
+    # offending field.
+    try:
+        validate_cron(payload.cron_expression)
+    except CronValidationError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid cron expression: {exc}",
+        )
 
     config = {
         "asset_ids": [str(a) for a in payload.asset_ids],
@@ -117,6 +127,21 @@ async def update_schedule(
         raise HTTPException(status_code=404, detail="Schedule not found")
 
     update_data = payload.model_dump(exclude_unset=True)
+
+    # v2.4.26 audit: same cron validation as create_schedule. Pre-2.4.26
+    # a PATCH could clobber a valid schedule with a parse-fail string,
+    # silently bricking a previously-working scheduled scan. The check
+    # runs before any mutation so a 400 leaves the existing row intact.
+    new_cron = update_data.get("cron_expression")
+    if new_cron is not None:
+        try:
+            validate_cron(new_cron)
+        except CronValidationError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid cron expression: {exc}",
+            )
+
     for field, value in update_data.items():
         if field == "features" and value is not None:
             config = schedule.config or {}

--- a/packages/api/app/utils/cron.py
+++ b/packages/api/app/utils/cron.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2024-2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+# NIS2 Compliance Platform — https://github.com/fabriziosalmi/nis2-public
+"""
+v2.4.26 audit: validate cron expressions at create/update time.
+
+Pre-2.4.26 the only check on `POST /api/v1/schedules` was that the cron
+string had 5 whitespace-separated fields. Any garbage in those fields
+("99 99 99 99 99", "a b c d e") was accepted by the API; the schedule
+silently never fired because `app.tasks.scan_tasks._should_run` swallows
+parse exceptions and returns False. The user saw no error at create
+time, no error in the schedules list, and no scans firing — a
+particularly painful "looks valid, doesn't work" failure mode.
+
+Why a hand-rolled parser instead of `croniter`:
+  - We already ship a parser in `_should_run` (scan_tasks.py); adding a
+    second one would let validation drift away from execution. This
+    module is the single source of truth.
+  - `croniter` introduces a runtime dependency for one validator —
+    weight-bearing in CI and Docker images — for code we can fit in
+    ~80 lines.
+  - Vixie cron syntax we accept is a strict subset (no L, W, # or @
+    keywords); rolling our own keeps the surface area exactly what
+    `_should_run` understands. If a user submits `@daily`, we want a
+    400 with a hint, not silent acceptance plus runtime parse failure.
+
+What's accepted, per field:
+  - `*`                  every value
+  - `N`                  exact value
+  - `N-M`                inclusive range, N <= M
+  - `N,M,K`              list of values / ranges
+  - `* / S` or `N-M / S` step (must be positive integer)
+
+Field ranges:
+  - minute   0-59
+  - hour     0-23
+  - dom      1-31  (day-of-month)
+  - month    1-12
+  - dow      0-7   (Sunday is both 0 AND 7, accepted by both forms)
+
+Anything else (letters, day names, @keywords, special chars) is rejected
+with a 400-friendly error message that points at the offending field.
+"""
+from __future__ import annotations
+
+
+_FIELD_RANGES: list[tuple[str, int, int]] = [
+    ("minute", 0, 59),
+    ("hour", 0, 23),
+    ("day-of-month", 1, 31),
+    ("month", 1, 12),
+    ("day-of-week", 0, 7),
+]
+
+
+class CronValidationError(ValueError):
+    """Raised when a cron expression cannot be parsed.
+
+    Inherits from ValueError so callers can catch either; the schedules
+    router converts it to an HTTP 400 with the message preserved.
+    """
+
+
+def _parse_int(token: str, lo: int, hi: int, field_name: str) -> int:
+    try:
+        value = int(token)
+    except ValueError:
+        raise CronValidationError(
+            f"{field_name}: '{token}' is not a number"
+        )
+    if value < lo or value > hi:
+        raise CronValidationError(
+            f"{field_name}: {value} is outside the allowed range {lo}-{hi}"
+        )
+    return value
+
+
+def _validate_field(field: str, lo: int, hi: int, field_name: str) -> None:
+    """Validate a single cron field token (one of 5 in the expression).
+
+    Recursive on the comma-separated list form so `1,3-5,*/10` is a
+    single call to `_validate_field` that delegates to itself per
+    sub-token. This mirrors the matcher in `scan_tasks._should_run`
+    so the two stay in lockstep.
+    """
+    if not field:
+        raise CronValidationError(f"{field_name}: empty field not allowed")
+
+    # Comma list: validate each sub-expression independently. We catch
+    # `,,` (empty sub-tokens) at this layer rather than below so the
+    # error message points at the list, not at the empty piece.
+    if "," in field:
+        sub_tokens = field.split(",")
+        if any(not s for s in sub_tokens):
+            raise CronValidationError(
+                f"{field_name}: empty list element in '{field}'"
+            )
+        for sub in sub_tokens:
+            _validate_field(sub.strip(), lo, hi, field_name)
+        return
+
+    # Step form: `<base>/<step>`. The base may itself be `*`, a single
+    # value, or a range — each handled by the recursion below after we
+    # peel off the step.
+    if "/" in field:
+        try:
+            base, step_raw = field.split("/", 1)
+        except ValueError:
+            # Should be unreachable given `/` in field, but defensive.
+            raise CronValidationError(f"{field_name}: malformed step '{field}'")
+        if not base or not step_raw:
+            raise CronValidationError(
+                f"{field_name}: '{field}' has an empty base or step"
+            )
+        step = _parse_int(step_raw, 1, max(hi, 1), field_name)
+        if step <= 0:
+            raise CronValidationError(
+                f"{field_name}: step must be a positive integer, got {step}"
+            )
+        # Recurse on the base (which is itself a valid sub-form).
+        _validate_field(base, lo, hi, field_name)
+        return
+
+    if field == "*":
+        return
+
+    # Range form: `<lo>-<hi>`, both ends within [lo, hi], lo <= hi.
+    if "-" in field:
+        try:
+            low_raw, high_raw = field.split("-", 1)
+        except ValueError:
+            raise CronValidationError(f"{field_name}: malformed range '{field}'")
+        low = _parse_int(low_raw, lo, hi, field_name)
+        high = _parse_int(high_raw, lo, hi, field_name)
+        if low > high:
+            raise CronValidationError(
+                f"{field_name}: range start {low} is greater than end {high}"
+            )
+        return
+
+    # Plain single value.
+    _parse_int(field, lo, hi, field_name)
+
+
+def validate_cron(expression: str) -> None:
+    """Validate a 5-field Vixie-style cron expression.
+
+    Raises `CronValidationError` (a `ValueError` subclass) on any
+    parsing or range error. Returns None on success.
+
+    Whitespace is normalised: leading/trailing spaces are stripped, and
+    runs of internal whitespace collapse to a single split — `"  0  9
+    *  *  1-5  "` is treated the same as `"0 9 * * 1-5"`.
+    """
+    if expression is None:
+        raise CronValidationError("cron expression is required")
+    parts = expression.strip().split()
+    if len(parts) != 5:
+        raise CronValidationError(
+            f"cron expression must have exactly 5 fields "
+            f"(minute hour day-of-month month day-of-week); got {len(parts)}"
+        )
+    for token, (field_name, lo, hi) in zip(parts, _FIELD_RANGES):
+        _validate_field(token, lo, hi, field_name)

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nis2-api"
-version = "2.4.25"
+version = "2.4.26"
 description = "NIS2 Compliance Platform API"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/api/tests/test_api.py
+++ b/packages/api/tests/test_api.py
@@ -264,7 +264,7 @@ class TestOpenAPI:
         assert resp.status_code == 200
         schema = resp.json()
         assert schema["info"]["title"] == "NIS2 Compliance Platform API"
-        assert schema["info"]["version"] == "2.4.25"
+        assert schema["info"]["version"] == "2.4.26"
 
     def test_all_router_tags_present(self, client):
         resp = client.get("/openapi.json")

--- a/packages/api/tests/test_api_key_scopes.py
+++ b/packages/api/tests/test_api_key_scopes.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2024-2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+# NIS2 Compliance Platform — https://github.com/fabriziosalmi/nis2-public
+"""
+v2.4.26 unit tests for the API-key scope validator.
+
+The validator lives in `app.routers.api_keys._validate_scopes`. Pre-2.4.26
+the create endpoint accepted any list of strings as scopes — including
+empty strings, unknown verbs, and duplicates — and persisted them. The
+UI then implied enforcement that didn't exist.
+
+These tests pin the canonical vocabulary at the point where it's
+checked. Route-level enforcement of the scopes (refusing a `scan:write`
+call from a key with only `scan:read`) is a separate, larger
+behavioural change tracked for a follow-up patch.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers.api_keys import VALID_API_KEY_SCOPES, _validate_scopes
+
+
+class TestValidScopes:
+    def test_default_set_passes(self) -> None:
+        # The default in ApiKeyCreate.Field; if this ever drifts away
+        # from the vocabulary, this test fails before users do.
+        assert _validate_scopes(["scan:read", "scan:write", "report:read"]) == [
+            "scan:read",
+            "scan:write",
+            "report:read",
+        ]
+
+    def test_single_scope(self) -> None:
+        assert _validate_scopes(["scan:read"]) == ["scan:read"]
+
+    def test_all_scopes(self) -> None:
+        # Pass the whole vocabulary in (sorted to keep the test stable).
+        sorted_all = sorted(VALID_API_KEY_SCOPES)
+        assert _validate_scopes(sorted_all) == sorted_all
+
+    def test_whitespace_trimmed(self) -> None:
+        # The cleaner strips surrounding whitespace so a copy-paste
+        # from a UI text field with stray spaces still works.
+        assert _validate_scopes(["  scan:read  "]) == ["scan:read"]
+
+    def test_none_passes_through(self) -> None:
+        # None means "no scopes field on the request" — the schema
+        # default is applied elsewhere; the validator should not
+        # over-reach and reject None.
+        assert _validate_scopes(None) is None
+
+
+class TestInvalidScopes:
+    def test_rejects_unknown_scope(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_scopes(["yolo:read"])
+        assert exc_info.value.status_code == 400
+        assert "unknown scope" in exc_info.value.detail.lower()
+        # The error message lists the allowed scopes so the UI can
+        # show a hint without an extra round-trip.
+        assert "scan:read" in exc_info.value.detail
+
+    def test_rejects_typo_in_known_scope(self) -> None:
+        # `scan:reads` (extra s) used to silently work pre-2.4.26.
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_scopes(["scan:reads"])
+        assert exc_info.value.status_code == 400
+
+    def test_rejects_empty_string(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_scopes([""])
+        assert exc_info.value.status_code == 400
+        assert "empty" in exc_info.value.detail.lower()
+
+    def test_rejects_whitespace_only(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_scopes(["   "])
+        assert exc_info.value.status_code == 400
+
+    def test_rejects_empty_list(self) -> None:
+        # Distinct from None: explicit empty list is user error.
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_scopes([])
+        assert exc_info.value.status_code == 400
+        assert "empty" in exc_info.value.detail.lower()
+
+    def test_rejects_duplicate(self) -> None:
+        # Duplicates are almost certainly UI bugs / copy-paste; we
+        # surface them rather than silently dedupe.
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_scopes(["scan:read", "scan:read"])
+        assert exc_info.value.status_code == 400
+        assert "duplicate" in exc_info.value.detail.lower()
+
+    def test_rejects_non_list(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_scopes("scan:read")  # type: ignore[arg-type]
+        assert exc_info.value.status_code == 400
+
+    def test_rejects_non_string_element(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_scopes(["scan:read", 42])  # type: ignore[list-item]
+        assert exc_info.value.status_code == 400
+
+
+class TestVocabularyShape:
+    """Pin the vocabulary itself so adding a scope is a deliberate
+    one-line change to api_keys.py PLUS this test, never an accident."""
+
+    def test_vocabulary_is_immutable(self) -> None:
+        assert isinstance(VALID_API_KEY_SCOPES, frozenset)
+
+    def test_every_scope_has_resource_and_verb(self) -> None:
+        # Shape: <resource>:<verb>. Verb must be `read` or `write`.
+        for scope in VALID_API_KEY_SCOPES:
+            assert ":" in scope, f"scope {scope!r} missing colon"
+            resource, verb = scope.split(":", 1)
+            assert resource, f"scope {scope!r} has empty resource"
+            assert verb in {"read", "write"}, f"scope {scope!r} has bad verb"

--- a/packages/api/tests/test_cron_validator.py
+++ b/packages/api/tests/test_cron_validator.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2024-2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+# NIS2 Compliance Platform — https://github.com/fabriziosalmi/nis2-public
+"""
+v2.4.26 unit tests for `app.utils.cron`.
+
+Standalone — no DB / no FastAPI / no Celery. The validator is a pure
+function and these tests pin every accepted form (per Vixie cron) and
+the most common rejection cases. The corresponding *execution* logic
+in `app.tasks.scan_tasks._should_run` should accept exactly the same
+forms; if a future change to either side widens or narrows the surface,
+adjust both files together.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.utils.cron import CronValidationError, validate_cron
+
+
+class TestAccepted:
+    """Each test is one Vixie-cron form documented in the module docstring.
+
+    None of these should raise.
+    """
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "* * * * *",                    # every minute
+            "0 9 * * 1-5",                  # weekdays 9am
+            "*/5 * * * *",                  # every 5 minutes
+            "0 0 1 * *",                    # midnight first of month
+            "0 0 1 1 *",                    # midnight Jan 1
+            "30 14 * * 0",                  # Sunday 14:30 (dow=0)
+            "30 14 * * 7",                  # Sunday 14:30 (dow=7 — both forms)
+            "0,15,30,45 * * * *",           # quarter-hourly
+            "0 9-17 * * 1-5",               # business hours
+            "0 9-17/2 * * 1-5",             # business hours, every 2h
+            "1-10/2 * * * *",               # ranged step
+            "0 0 31 12 *",                  # Dec 31 midnight (dom=31 boundary)
+            "59 23 * * *",                  # last minute of day
+            "0 0 * * *",                    # daily midnight
+            "  0  9  *  *  1-5  ",          # whitespace tolerance
+        ],
+    )
+    def test_accepted(self, expr: str) -> None:
+        # Returns None on success; the lack of exception is the assertion.
+        assert validate_cron(expr) is None
+
+
+class TestFieldCount:
+    @pytest.mark.parametrize("expr", ["", " ", "* * * *", "* * * * * *"])
+    def test_wrong_field_count(self, expr: str) -> None:
+        with pytest.raises(CronValidationError, match="exactly 5 fields"):
+            validate_cron(expr)
+
+    def test_none(self) -> None:
+        with pytest.raises(CronValidationError, match="required"):
+            validate_cron(None)  # type: ignore[arg-type]
+
+
+class TestRangeChecks:
+    """The agent-flagged regression: pre-2.4.26 `99 99 99 99 99` was accepted."""
+
+    def test_rejects_minute_too_high(self) -> None:
+        with pytest.raises(CronValidationError, match="minute"):
+            validate_cron("60 0 1 1 0")
+
+    def test_rejects_minute_negative_via_letters(self) -> None:
+        with pytest.raises(CronValidationError, match="minute.*not a number"):
+            validate_cron("a 0 1 1 0")
+
+    def test_rejects_hour_too_high(self) -> None:
+        with pytest.raises(CronValidationError, match="hour"):
+            validate_cron("0 24 1 1 0")
+
+    def test_rejects_dom_zero(self) -> None:
+        # day-of-month is 1-indexed; 0 is invalid.
+        with pytest.raises(CronValidationError, match="day-of-month"):
+            validate_cron("0 0 0 1 0")
+
+    def test_rejects_dom_too_high(self) -> None:
+        with pytest.raises(CronValidationError, match="day-of-month"):
+            validate_cron("0 0 32 1 0")
+
+    def test_rejects_month_zero(self) -> None:
+        with pytest.raises(CronValidationError, match="month"):
+            validate_cron("0 0 1 0 0")
+
+    def test_rejects_month_too_high(self) -> None:
+        with pytest.raises(CronValidationError, match="month"):
+            validate_cron("0 0 1 13 0")
+
+    def test_rejects_dow_too_high(self) -> None:
+        with pytest.raises(CronValidationError, match="day-of-week"):
+            validate_cron("0 0 1 1 8")
+
+    def test_rejects_audit_smoking_gun(self) -> None:
+        # The exact garbage the agent flagged. Pre-2.4.26 the schedules
+        # API accepted this and the schedule silently never fired.
+        with pytest.raises(CronValidationError):
+            validate_cron("99 99 99 99 99")
+
+    def test_rejects_letters_only(self) -> None:
+        # Same agent-flagged failure mode: legible-looking gibberish.
+        with pytest.raises(CronValidationError):
+            validate_cron("a b c d e")
+
+
+class TestRangeForm:
+    def test_inverted_range_rejected(self) -> None:
+        # 17-9 is invalid: start > end. A naive parser would silently
+        # generate an empty match-set and the schedule would never fire.
+        with pytest.raises(CronValidationError, match="range start.*greater than"):
+            validate_cron("0 17-9 * * *")
+
+    def test_range_endpoint_at_field_max_accepted(self) -> None:
+        validate_cron("0 0-23 * * *")   # full hour range
+        validate_cron("0-59 * * * *")   # full minute range
+
+    def test_range_endpoint_one_past_field_max_rejected(self) -> None:
+        with pytest.raises(CronValidationError, match="hour"):
+            validate_cron("0 0-24 * * *")
+
+
+class TestStepForm:
+    def test_zero_step_rejected(self) -> None:
+        with pytest.raises(CronValidationError):
+            validate_cron("*/0 * * * *")
+
+    def test_negative_step_rejected(self) -> None:
+        # `*/-5` will fail at the int parse with "outside the allowed
+        # range" because the parser bounds steps to [1, hi].
+        with pytest.raises(CronValidationError):
+            validate_cron("*/-5 * * * *")
+
+    def test_step_with_explicit_base(self) -> None:
+        validate_cron("5/10 * * * *")   # every 10 starting at minute 5
+
+    def test_step_with_range_base(self) -> None:
+        validate_cron("0-30/5 * * * *")
+
+    def test_empty_base_rejected(self) -> None:
+        with pytest.raises(CronValidationError, match="empty base"):
+            validate_cron("/5 * * * *")
+
+    def test_empty_step_rejected(self) -> None:
+        with pytest.raises(CronValidationError, match="empty base or step"):
+            validate_cron("*/  * * * *")
+
+
+class TestListForm:
+    def test_simple_list(self) -> None:
+        validate_cron("0,15,30,45 * * * *")
+
+    def test_list_with_ranges_and_steps(self) -> None:
+        validate_cron("0,15-20,30/5 * * * *")
+
+    def test_empty_list_element_rejected(self) -> None:
+        with pytest.raises(CronValidationError, match="empty list element"):
+            validate_cron("0,,30 * * * *")
+
+    def test_list_value_out_of_range_rejected(self) -> None:
+        # Catch the case where ONE element of a list is out of range
+        # (the others are fine). Prevents a partial-validation regression.
+        with pytest.raises(CronValidationError, match="minute"):
+            validate_cron("0,30,99 * * * *")
+
+
+class TestVixieKeywordsRejected:
+    """We deliberately do NOT accept @-keywords (@daily, @hourly, @reboot)
+    or day names (MON, TUE) because the executor in `_should_run` doesn't
+    handle them either. Silent acceptance + runtime parse failure is the
+    exact failure mode this patch closes."""
+
+    @pytest.mark.parametrize("expr", ["@daily", "@hourly", "@reboot"])
+    def test_keyword_rejected(self, expr: str) -> None:
+        with pytest.raises(CronValidationError):
+            validate_cron(expr)
+
+    def test_day_name_rejected(self) -> None:
+        with pytest.raises(CronValidationError):
+            validate_cron("0 0 * * MON")

--- a/packages/scanner/pyproject.toml
+++ b/packages/scanner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nis2scan"
-version = "2.4.25"
+version = "2.4.26"
 description = "NIS2 Directive compliance scanner engine"
 requires-python = ">=3.10"
 dependencies = [

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nis2/web",
-  "version": "2.4.25",
+  "version": "2.4.26",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

API surface audit triage. Closes the only **real** BLOCKER from the v2.4.25 audit pass plus one verified SERIOUS gap. Documents transparently that 2 of the 3 reported blockers turned out to be false positives on close reading of the source.

### Audit transparency: 2 of 3 reported blockers were false positives

| # | Reported issue | Verdict |
|---|---|---|
| 1 | API key expiration race | **False positive.** Inline expiry check raises 401 unconditionally; no stale-state window. |
| 2 | Missing \`db.commit\` on DELETE | **False positive.** \`get_db\` is a context-manager dependency that commits at request close. |
| 3 | Cron validation no-op | **REAL.** Fixed in this patch. |

The agent's report on #1 and #2 missed the dependency lifecycle. Documenting in the CHANGELOG so a future reader doesn't think a phantom security bug existed and was silently dropped.

### Real fixes

- **Cron validation** (was BLOCKER): new \`app/utils/cron.py:validate_cron\`. Wired into \`create_schedule\` AND \`update_schedule\`. Accepts exactly the grammar \`_should_run\` understands — single source of truth, no acceptance/execution drift.
- **API key scope validation** (was SERIOUS): canonical \`VALID_API_KEY_SCOPES\` frozenset + \`_validate_scopes\` rejecting unknown / empty / duplicate / non-string entries.

## Test plan

- [x] **62 new unit tests** (47 cron + 15 scope), all green
- [x] Local: 126 standalone tests pass (no regressions)
- [ ] CI: full backend + integration suite (waiting)

## Deferred

- Route-level enforcement of API key scopes — separate behavioural change with its own migration story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)