### PR TITLE
fix(ci): resolve remaining gitleaks and E2E 422 failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
       CORS_ORIGINS: http://localhost:3000
       # Credentials used both to register the E2E user and to run the suite.
       E2E_LIVE_BASE_URL: http://localhost:8000
-      E2E_LIVE_EMAIL: e2e-ci@nis2.local
+      E2E_LIVE_EMAIL: e2e-ci@example.com
       E2E_LIVE_PASSWORD: E2eC!password99
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -19,6 +19,10 @@ description = "NIS2-specific allowlist for known test fixtures and CI placeholde
 # without them the scanner has no positive coverage. None are real.
 paths = [
     '''packages/scanner/tests/test_features\.py''',
+    # test_secrets_detection.py embeds canonical JWT example tokens (from jwt.io
+    # documentation) to verify the scanner's JWT detection rule fires. These are
+    # well-known public examples; none are real credentials.
+    '''packages/scanner/tests/test_secrets_detection\.py''',
     # test_jwt_rs256.py patches settings with placeholder HS256 secrets and uses
     # runtime-generated RSA keypairs for round-trip coverage. None are real.
     '''packages/api/tests/test_jwt_rs256\.py''',


### PR DESCRIPTION
## Summary

Two remaining CI failures after v2.5.11.

- **Gitleaks 1 remaining leak**: `packages/scanner/tests/test_secrets_detection.py` embeds the canonical jwt.io example JWT (`eyJhbGciOiJIUzI1NiJ9...`) to exercise the scanner's JWT detection rule. Added to the paths allowlist. Verified locally: `gitleaks detect` now exits 0 over all 111 commits.

- **E2E seed still 422**: `email-validator>=2.0` rejects `e2e-ci@nis2.local` even with `check_deliverability=False` because `.local` is a special-use reserved domain (mDNS/Bonjour), not on IANA's public TLD list. Changed `E2E_LIVE_EMAIL` to `e2e-ci@example.com` — `example.com` is the canonical documentation domain and accepted by email-validator unconditionally.

## Test plan
- [ ] `gitleaks detect --source . --no-banner --config .gitleaks.toml` → no leaks
- [ ] E2E seed curl returns 201 with `example.com` email

🤖 Generated with [Claude Code](https://claude.com/claude-code)