### PR TITLE
fix(e2e): add finding:read and asset:read scopes to E2E API key

### DIFF
--- a/packages/api/tests/test_e2e_live.py
+++ b/packages/api/tests/test_e2e_live.py
@@ -467,7 +467,10 @@ class TestApiKeyAuth:
         """
         resp = client.post(
             "/api/v1/api-keys",
-            json={"name": f"e2e-dualauth-{uuid.uuid4().hex[:8]}"},
+            json={
+                "name": f"e2e-dualauth-{uuid.uuid4().hex[:8]}",
+                "scopes": ["scan:read", "finding:read", "asset:read"],
+            },
             headers=_csrf_headers(auth),
         )
         assert resp.status_code == 201, f"create key: {resp.status_code} {resp.text}"


### PR DESCRIPTION
## Summary

The `minted_key` fixture in `TestApiKeyAuth` created an API key with the default scope set `["scan:read", "scan:write", "report:read"]`. The scope enforcement added in v2.5.9 means `/findings` and `/assets` reject keys that lack `finding:read` and `asset:read` respectively — causing `test_api_key_authenticates_list_findings` and `test_api_key_authenticates_list_assets` to get 403.

Added those two scopes explicitly to the fixture so all three dual-auth tests (scans, findings, assets) use a key that covers the endpoints they exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)