### PR TITLE
docs: update README for v2.5.11 — TOTP MFA, RS256, RLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The compliance matrix references all ten sub-paragraphs (a) through (j). Several
 | (g) Cyber hygiene and training | Awareness, phishing simulation | **Manual** | Governance checklist (human verification required by design) |
 | (h) Cryptography | Crypto policy, key management | **Partial** — automated for public-facing TLS | Technical validation (TLS version, cipher suites, cert expiry, HSTS) + checklist for key-management policy |
 | (i) Human resources security | Onboarding/offboarding, screening, PAM | **Manual** | Governance checklist (human verification required by design) |
-| (j) Authentication and access control | MFA, RBAC, PAM, SSO, access logging | **Partial** — RBAC + audit log implemented; TOTP MFA planned | Role-based access (owner/admin/auditor/viewer), API key scopes, dual-auth, per-request audit log; TOTP MFA tracked in [#86](https://github.com/fabriziosalmi/nis2-public/issues/86) |
+| (j) Authentication and access control | MFA, RBAC, PAM, SSO, access logging | **Implemented** — TOTP MFA, RBAC, audit log, API key scopes | TOTP MFA (`POST /auth/totp/setup\|verify\|disable`), MFA-gated login flow, role-based access (owner/admin/auditor/viewer), per-request scoped API keys (`dual_auth_with_scope`), per-request audit log, RS256 JWT with `GET /.well-known/jwks.json` |
 
 **Legend**: *Implemented* = fully automated with no manual step required. *Partial* = automated checks cover the technically observable surface; organisational controls require human verification. *Manual* = the directive explicitly requires human judgement — automation cannot substitute.
 
@@ -201,7 +201,7 @@ These automated checks verify whether the security measures documented in your g
 
 | Router | Endpoints | Purpose |
 |--------|-----------|---------|
-| `/api/v1/auth` | 10 | JWT authentication, registration, change-password, forgot/reset password, **switch active organization** |
+| `/api/v1/auth` | 13 | JWT authentication, registration, change-password, forgot/reset password, **switch active organization**, TOTP setup/verify/disable |
 | `/api/v1/scans` | 8 | Scan management, results, comparison. Read endpoints accept API-key Bearer auth |
 | `/api/v1/findings` | 5 | Finding lifecycle (open/acknowledged/resolved). Read endpoints accept API-key Bearer auth |
 | `/api/v1/assets` | 6 | Asset inventory management. Read endpoints accept API-key Bearer auth |
@@ -218,6 +218,9 @@ These automated checks verify whether the security measures documented in your g
 | `/api/v1/deadlines` | 1 | Compliance deadline countdown |
 | `/api/v1/csirt/emergency` | 1 | "Red Button" — instant Early Warning payload |
 | `/api/v1/mcp` | 2 | Model Context Protocol for AI assistants |
+| `/.well-known/jwks.json` | 1 | RS256 public key set for JWT verification |
+| `/.well-known/security.txt` | 1 | Responsible disclosure contact |
+| `/health`, `/health/live`, `/health/ready` | 3 | Three-tier liveness / readiness (DB + Redis + Celery) |
 
 ---
 
@@ -243,7 +246,7 @@ Designed for NIS2 consultants and DPO-as-a-service managing multiple clients:
 | **Backend** | FastAPI, SQLAlchemy (async), Pydantic v2, Celery, Redis, slowapi |
 | **Database** | PostgreSQL 16 |
 | **Scanner** | Python asyncio, aiohttp, dnspython, Playwright, python-whois |
-| **Security** | CSP/HSTS/X-Frame-Options at the proxy and API layers, rate limiting, SSRF prevention, API key auth |
+| **Security** | CSP/HSTS/X-Frame-Options at the proxy and API layers, rate limiting (SlowAPI), SSRF prevention, API key auth, TOTP MFA, RS256 JWT + JWKS, RLS row-level isolation, audit log retention (90 days) |
 | **AI / MCP** | MCP Server (stdio + HTTP), Ollama/OpenAI |
 | **Infra** | Docker, Caddy 2 (auto-HTTPS), GitHub Actions CI |
 

--- a/packages/api/tests/test_e2e_live.py
+++ b/packages/api/tests/test_e2e_live.py
@@ -467,7 +467,10 @@ class TestApiKeyAuth:
         """
         resp = client.post(
             "/api/v1/api-keys",
-            json={"name": f"e2e-dualauth-{uuid.uuid4().hex[:8]}"},
+            json={
+                "name": f"e2e-dualauth-{uuid.uuid4().hex[:8]}",
+                "scopes": ["scan:read", "finding:read", "asset:read"],
+            },
             headers=_csrf_headers(auth),
         )
         assert resp.status_code == 201, f"create key: {resp.status_code} {resp.text}"


### PR DESCRIPTION
## Summary

- **Art. 21(j)** compliance status updated from *Partial* to **Implemented**: TOTP MFA is live (`POST /auth/totp/setup|verify|disable`), RS256 JWT with JWKS endpoint, scoped API keys — closes #86, #87, #88
- **Security row** in tech stack table updated to reflect SlowAPI rate limiting, TOTP MFA, RS256 JWT + JWKS, RLS row-level isolation, and 90-day audit log retention
- **API surface table** updated: auth endpoint count corrected; `/.well-known/jwks.json`, `/.well-known/security.txt`, and three-tier health endpoints added

`docs/index.md` has no feature list or changelog section (it's only frontmatter + `<Home />`) so no change was needed there.

## Test plan
- [ ] Verify Art. 21 compliance matrix renders correctly in the GitHub README
- [ ] Confirm no stale "planned" or "#86/#87/#88" references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)