### PR TITLE
Bump aiohttp to 3.14.0 (medium)

### DIFF
--- a/packages/scanner/requirements.txt
+++ b/packages/scanner/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.13.5
+aiohttp==3.14.0
 aiodns==4.0.4
 click==8.4.0
 pyyaml==6.0.1


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `aiohttp` `3.13.5` → `3.14.0`
**Manifest:** `packages/scanner/requirements.txt`
**Severity:** medium
**Advisory:** AIOHTTP is vulnerable to cross-origin redirect with per-request cookies CVE-2026-34993, CVE-2026-47265

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `627f2d9f30540356` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"627f2d9f30540356","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->