### PR TITLE
Add accessible <title> element to SVG

### DIFF
--- a/packages/web/src/components/brand/logo.tsx
+++ b/packages/web/src/components/brand/logo.tsx
@@ -39,6 +39,7 @@ export function Logo({
   // too. `useId` produces a stable, SSR-safe, per-instance id.
   const reactId = useId()
   const gradientId = `nis2-logo-grad-${reactId.replace(/[:]/g, "")}`
+  const titleId = `nis2-logo-title-${reactId.replace(/[:]/g, "")}`
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -52,12 +53,13 @@ export function Logo({
       className={cn("shrink-0", className)}
       // role + aria-label make this an image for screen readers; without
       // them the SVG is announced as a meaningless decorative blob.
-      aria-label="NIS2 Platform"
+      aria-labelledby={titleId}
       role="img"
       // Prevents the SVG from becoming a tab stop in legacy IE/Edge
       // engines — harmless on every modern browser.
       focusable="false"
     >
+      <title id={titleId}>NIS2 Platform</title>
       <defs>
         <linearGradient
           id={gradientId}


### PR DESCRIPTION
### FabGPT — code quality

**File:** `packages/web/src/components/brand/logo.tsx`

**Rationale:** Screen readers benefit from a <title> element inside the SVG for better description. Adding it improves accessibility without altering visual output or API.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `gpt-oss-120b` · task `7923849a3fa47439` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"7923849a3fa47439","source":"quality","model":"gpt-oss-120b","severity":"INFO","iterations":1,"inference_s":16.9,"prompt_sha":"e50c2957a3872f91","triage":"INFO"} -->