### PR TITLE
Escape special characters in generated IDs to prevent invalid SVG references

### DIFF
--- a/packages/web/src/components/brand/logo.tsx
+++ b/packages/web/src/components/brand/logo.tsx
@@ -38,8 +38,11 @@ export function Logo({
   // -translate-x-full), the gradient disappears on the desktop instance
   // too. `useId` produces a stable, SSR-safe, per-instance id.
   const reactId = useId()
-  const gradientId = `nis2-logo-grad-${reactId.replace(/[:]/g, "")}`
-  const titleId = `nis2-logo-title-${reactId.replace(/[:]/g, "")}`
+  // Escape any characters that could break CSS selector or SVG fragment syntax.
+  // We replace all non-alphanumeric characters to ensure a safe ID.
+  const safeId = reactId.replace(/[^a-zA-Z0-9]/g, "")
+  const gradientId = `nis2-logo-grad-${safeId}`
+  const titleId = `nis2-logo-title-${safeId}`
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
### FabGPT — code quality

**File:** `packages/web/src/components/brand/logo.tsx`

**Rationale:** The `useId()` hook may produce IDs containing colons (`:`), which are then stripped manually with `.replace(/[:]/g, '')`. However, React 18+ `useId()` can produce other characters like hyphens or underscores, and future versions might change the format. More critically, if the ID contains characters invalid in CSS selectors (e.g., `:` remains in some edge cases due to incomplete escaping), the resulting `url(#${gradientId})` may become invalid, causing gradients to fail silently in rendering. Using a robust escaping strategy ensures the ID is always a valid SVG fragment identifier.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `7923849a3fa47439` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"7923849a3fa47439","source":"quality","model":"qwen3-coder-next","severity":"WARN","iterations":1,"inference_s":19.78,"prompt_sha":"7ea6b7d5479cc7ae","triage":"WARN"} -->