### PR TITLE
Bump aiohttp to 3.14.1 (medium)

### DIFF
--- a/packages/scanner/requirements.txt
+++ b/packages/scanner/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.14.0
+aiohttp==3.14.1
 aiodns==4.0.4
 click==8.4.0
 pyyaml==6.0.1


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `aiohttp` `3.14.0` → `3.14.1`
**Manifest:** `packages/scanner/requirements.txt`
**Severity:** medium
**Advisories:** CVE-2026-54273, CVE-2026-54274, CVE-2026-54275, CVE-2026-54276, CVE-2026-54277, CVE-2026-54278, CVE-2026-54279, CVE-2026-54280

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `352e16c99e520f8c` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"352e16c99e520f8c","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->