### PR TITLE
Add test for missing items key in bulk-update payload

### DIFF
--- a/packages/api/tests/test_governance_bulk.py
+++ b/packages/api/tests/test_governance_bulk.py
@@ -106,6 +106,12 @@ def test_bulk_update_string_too_long(client_admin):
     assert resp.status_code == 422
     assert "assigned_to_name" in resp.text
 
+def test_bulk_update_missing_items_key(client_admin):
+    payload = {"other_field": "value"}  # Missing required 'items' key
+    resp = client_admin.post("/api/v1/governance/bulk-update", json=payload)
+    assert resp.status_code == 422
+    assert "items" in resp.text
+
 def test_bulk_update_valid_passes_schema(client_admin):
     payload = {
         "items": [


### PR DESCRIPTION
### FabGPT — code quality

**File:** `packages/api/tests/test_governance_bulk.py`

**Rationale:** The current test suite validates schema errors for invalid item contents but omits a test for the top-level payload structure — specifically, whether omitting the required 'items' key triggers a 422 error. Adding this test ensures the API contract is fully enforced at the request level, improving robustness and preventing unexpected server-side failures due to malformed payloads.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `02d3ba2cd5b4b7e6` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"02d3ba2cd5b4b7e6","source":"quality","model":"qwen3-coder-next","severity":"INFO","iterations":1,"inference_s":20.96,"prompt_sha":"7acb6ccaa37e221c","triage":"INFO"} -->