### PR TITLE
security: close certificate/scanner SSRF, gate schedules, fix prod Celery (H1–H4, M6)

### DIFF
--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -104,6 +104,16 @@ services:
     volumes:
       - reports-data:/tmp/nis2-reports
     env_file: ../../.env
+    environment:
+      # Tells app.database to use NullPool. Each Celery task runs in a
+      # fresh asyncio loop (asyncio.run per task); a pooled asyncpg
+      # connection held over from a prior task carries a now-closed loop
+      # and throws "Future attached to a different loop" on reuse. The dev
+      # compose sets this on worker + beat — prod MUST too, or scheduled
+      # scans, report generation, and incident-deadline alerts silently
+      # stop after the first task. See the _CELERY_WORKER_MODE comment
+      # block in packages/api/app/database.py.
+      CELERY_WORKER: "1"
     depends_on:
       postgres: { condition: service_healthy }
       redis: { condition: service_healthy }
@@ -135,6 +145,10 @@ services:
     volumes:
       - celerybeat_data:/var/celerybeat
     env_file: ../../.env
+    environment:
+      # Same NullPool fix as celery-worker above; the dev compose sets
+      # CELERY_WORKER on both services, so prod matches to avoid drift.
+      CELERY_WORKER: "1"
     depends_on:
       redis: { condition: service_healthy }
     restart: unless-stopped

--- a/packages/api/app/routers/certificates.py
+++ b/packages/api/app/routers/certificates.py
@@ -6,14 +6,33 @@ Certificate Intelligence API Router.
 Deep certificate analysis and monitoring.
 """
 
-from fastapi import APIRouter, Depends, HTTPException
+import logging
+from urllib.parse import quote
+
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from app.dependencies import get_current_org
+from app.dependencies import get_current_org, require_role
 from app.models.membership import Membership
 from app.models.user import User
+from app.routers.auth import limiter  # share the single Limiter instance
+from app.utils.target_validator import (
+    TargetValidationError,
+    ValidationResult,
+    validate_domain_pinned,
+)
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/certificates", tags=["certificates"])
+
+# Certificate analysis only makes sense against a TLS endpoint. Restricting the
+# port to known implicit-TLS service ports stops these endpoints from being used
+# as a general internal port scanner (e.g. probing 22/3306/6379/RDP) — a
+# defense-in-depth layer on top of the public-IP-only domain validation below.
+ALLOWED_TLS_PORTS = frozenset(
+    {443, 8443, 9443, 10443, 4443, 993, 995, 465, 636, 990, 5061}
+)
 
 
 class CertificateCheckRequest(BaseModel):
@@ -26,40 +45,94 @@ class CertificateBulkRequest(BaseModel):
     port: int = Field(default=443, ge=1, le=65535)
 
 
-@router.post("/check")
+def _require_tls_port(port: int) -> None:
+    """Reject non-TLS ports before any outbound connection is attempted."""
+    if port not in ALLOWED_TLS_PORTS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unsupported port {port}: only TLS service ports may be analyzed.",
+        )
+
+
+async def _validate_cert_target(domain: str) -> ValidationResult:
+    """SSRF guard for the certificate endpoints.
+
+    Mirrors the asset-creation pin (assets.py): resolve the domain, reject
+    private/reserved/blocked/malformed hosts BEFORE any outbound connection,
+    and return the IP pinned at validation time so the analyzer connects to
+    *that* IP — closing the DNS-rebinding TOCTOU window. The validation detail
+    is logged but never echoed back (it is an internal-network oracle).
+    """
+    try:
+        return await validate_domain_pinned(domain)
+    except TargetValidationError:
+        logger.warning("Certificate target rejected: %s", domain)
+        raise HTTPException(status_code=422, detail="Invalid or disallowed target.")
+
+
+@router.post("/check", dependencies=[Depends(require_role("admin", "auditor"))])
+@limiter.limit("20/minute")
 async def check_certificate(
+    request: Request,
     payload: CertificateCheckRequest,
     current_org: tuple[User, Membership] = Depends(get_current_org),
 ):
     """Deep certificate analysis for a single domain."""
     from nis2scan.certificate import CertificateAnalyzer
 
+    _require_tls_port(payload.port)
+    validation = await _validate_cert_target(payload.domain)
+
     analyzer = CertificateAnalyzer(timeout=10)
     try:
-        info = await analyzer.analyze(payload.domain, payload.port)
+        info = await analyzer.analyze(
+            validation.target_value, payload.port, pinned_ip=validation.pinned_ip
+        )
         return analyzer.to_dict(info)
-    except Exception as e:
-        raise HTTPException(status_code=422, detail=f"Certificate analysis failed: {e}")
+    except Exception:
+        # Generic message to the caller; full detail server-side only.
+        logger.exception(
+            "Certificate analysis failed for %s:%s",
+            validation.target_value,
+            payload.port,
+        )
+        raise HTTPException(status_code=422, detail="Certificate analysis failed.")
 
 
-@router.post("/bulk-check")
+@router.post("/bulk-check", dependencies=[Depends(require_role("admin", "auditor"))])
+@limiter.limit("5/minute")
 async def bulk_check_certificates(
+    request: Request,
     payload: CertificateBulkRequest,
     current_org: tuple[User, Membership] = Depends(get_current_org),
 ):
     """Analyze certificates for multiple domains at once."""
     import asyncio
+
     from nis2scan.certificate import CertificateAnalyzer
 
+    _require_tls_port(payload.port)
+
     analyzer = CertificateAnalyzer(timeout=10)
-    results = []
 
     async def _check(domain: str):
+        # Validate/pin every domain up front; an invalid one gets a generic
+        # per-item error and is never connected to.
         try:
-            info = await analyzer.analyze(domain, payload.port)
+            validation = await validate_domain_pinned(domain)
+        except TargetValidationError:
+            logger.warning("Bulk certificate target rejected: %s", domain)
+            return {"domain": domain, "error": "Invalid or disallowed target", "score": 0}
+        try:
+            info = await analyzer.analyze(
+                validation.target_value, payload.port, pinned_ip=validation.pinned_ip
+            )
             return analyzer.to_dict(info)
-        except Exception as e:
-            return {"domain": domain, "error": str(e), "score": 0}
+        except Exception:
+            logger.exception(
+                "Bulk certificate analysis failed for %s", validation.target_value
+            )
+            return {"domain": domain, "error": "Certificate analysis failed", "score": 0}
 
     tasks = [_check(d) for d in payload.domains]
     results = await asyncio.gather(*tasks)
@@ -81,16 +154,23 @@ async def bulk_check_certificates(
     }
 
 
-@router.get("/ct-logs/{domain}")
+@router.get(
+    "/ct-logs/{domain}", dependencies=[Depends(require_role("admin", "auditor"))]
+)
+@limiter.limit("30/minute")
 async def get_ct_logs(
+    request: Request,
     domain: str,
     current_org: tuple[User, Membership] = Depends(get_current_org),
 ):
     """Query Certificate Transparency logs for a domain via crt.sh."""
     import aiohttp
 
+    # crt.sh is a fixed external host (no SSRF surface — we never connect to
+    # `domain` itself), but the user-supplied value is interpolated into the
+    # query string, so URL-encode it.
     try:
-        url = f"https://crt.sh/?q={domain}&output=json"
+        url = f"https://crt.sh/?q={quote(domain, safe='')}&output=json"
         async with aiohttp.ClientSession() as session:
             async with session.get(
                 url, timeout=aiohttp.ClientTimeout(total=15)
@@ -121,5 +201,6 @@ async def get_ct_logs(
                         )
                 unique.sort(key=lambda x: x.get("not_before", ""), reverse=True)
                 return {"domain": domain, "total": len(unique), "entries": unique[:50]}
-    except Exception as e:
-        return {"domain": domain, "entries": [], "error": str(e)}
+    except Exception:
+        logger.exception("CT-log lookup failed for %s", domain)
+        return {"domain": domain, "entries": [], "error": "CT-log lookup failed"}

--- a/packages/api/app/routers/schedules.py
+++ b/packages/api/app/routers/schedules.py
@@ -127,6 +127,10 @@ async def update_schedule(
 ) -> ScheduleResponse:
     user, membership = current_org
 
+    # Security audit: mutating a schedule is privileged — gate like create_schedule.
+    if membership.role not in ("admin", "auditor"):
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+
     schedule = await db.get(ScanSchedule, schedule_id)
     if not schedule or schedule.organization_id != membership.organization_id:
         raise HTTPException(status_code=404, detail="Schedule not found")
@@ -167,6 +171,10 @@ async def delete_schedule(
 ) -> None:
     user, membership = current_org
 
+    # Security audit: deletion is the most destructive action here — admin only.
+    if membership.role != "admin":
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+
     schedule = await db.get(ScanSchedule, schedule_id)
     if not schedule or schedule.organization_id != membership.organization_id:
         raise HTTPException(status_code=404, detail="Schedule not found")
@@ -183,6 +191,12 @@ async def trigger_schedule(
 ):
     """Trigger an immediate run of a scheduled scan."""
     user, membership = current_org
+
+    # Security audit: a read-only viewer must not launch scans — gate like
+    # create_schedule. Triggering enqueues a Celery scan job, so an
+    # ungated endpoint is both privilege escalation and a DoS vector.
+    if membership.role not in ("admin", "auditor"):
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
 
     schedule = await db.get(ScanSchedule, schedule_id)
     if not schedule or schedule.organization_id != membership.organization_id:

--- a/packages/scanner/nis2scan/certificate.py
+++ b/packages/scanner/nis2scan/certificate.py
@@ -34,6 +34,9 @@ class CertificateInfo:
     domain: str
     ip: str = ""
     port: int = 443
+    # IP pinned by the caller (API SSRF validation). When set, all TLS
+    # connections target this IP with SNI=domain, defeating DNS rebinding.
+    connect_ip: str = ""
 
     # Basic cert fields
     subject: Dict[str, str] = field(default_factory=dict)
@@ -114,9 +117,17 @@ class CertificateAnalyzer:
     def __init__(self, timeout: int = 10):
         self.timeout = timeout
 
-    async def analyze(self, domain: str, port: int = 443) -> CertificateInfo:
-        """Full certificate analysis for a domain."""
+    async def analyze(
+        self, domain: str, port: int = 443, pinned_ip: Optional[str] = None
+    ) -> CertificateInfo:
+        """Full certificate analysis for a domain.
+
+        When `pinned_ip` is provided (the IP the API resolved + validated),
+        every TLS connection targets that IP with SNI=domain, so a DNS rebind
+        between validation and analysis cannot redirect us to an internal host.
+        """
         info = CertificateInfo(domain=domain, port=port)
+        info.connect_ip = pinned_ip or ""
 
         # 1. Get certificate via TLS handshake
         try:
@@ -161,7 +172,12 @@ class CertificateAnalyzer:
         context.check_hostname = False
         context.verify_mode = ssl.CERT_OPTIONAL
 
-        conn = asyncio.open_connection(info.domain, info.port, ssl=context)
+        conn = asyncio.open_connection(
+            info.connect_ip or info.domain,
+            info.port,
+            ssl=context,
+            server_hostname=info.domain,
+        )
         reader, writer = await asyncio.wait_for(conn, timeout=self.timeout)
 
         ssl_obj = writer.get_extra_info("ssl_object")
@@ -174,11 +190,15 @@ class CertificateAnalyzer:
         if not cert:
             raise ValueError("No certificate returned")
 
-        # IP
-        try:
-            info.ip = socket.gethostbyname(info.domain)
-        except socket.gaierror:
-            pass
+        # IP: prefer the pinned IP — re-resolving here would both block the
+        # event loop and re-open the rebinding window we just closed.
+        if info.connect_ip:
+            info.ip = info.connect_ip
+        else:
+            try:
+                info.ip = socket.gethostbyname(info.domain)
+            except socket.gaierror:
+                pass
 
         # Subject
         for rdn in cert.get("subject", ()):
@@ -286,7 +306,12 @@ class CertificateAnalyzer:
         """Analyze the certificate chain."""
         try:
             context = ssl.create_default_context()
-            conn = asyncio.open_connection(info.domain, info.port, ssl=context)
+            conn = asyncio.open_connection(
+                info.connect_ip or info.domain,
+                info.port,
+                ssl=context,
+                server_hostname=info.domain,
+            )
             reader, writer = await asyncio.wait_for(conn, timeout=self.timeout)
             ssl_obj = writer.get_extra_info("ssl_object")
             cert = ssl_obj.getpeercert()
@@ -354,7 +379,12 @@ class CertificateAnalyzer:
             context = ssl.create_default_context()
             context.check_hostname = False
             context.verify_mode = ssl.CERT_OPTIONAL
-            conn = asyncio.open_connection(info.domain, info.port, ssl=context)
+            conn = asyncio.open_connection(
+                info.connect_ip or info.domain,
+                info.port,
+                ssl=context,
+                server_hostname=info.domain,
+            )
             reader, writer = await asyncio.wait_for(conn, timeout=self.timeout)
             ssl_obj = writer.get_extra_info("ssl_object")
             cert = ssl_obj.getpeercert()
@@ -395,10 +425,18 @@ class CertificateAnalyzer:
     async def _check_pinning_headers(self, info: CertificateInfo) -> None:
         """Check for certificate pinning headers."""
         try:
-            url = f"https://{info.domain}:{info.port}/"
+            # Connect to the pinned IP (vhost via Host header), never follow
+            # redirects — both would otherwise re-resolve an attacker host.
+            host = info.connect_ip or info.domain
+            url = f"https://{host}:{info.port}/"
             async with aiohttp.ClientSession() as session:
-                async with session.get(url, timeout=aiohttp.ClientTimeout(total=self.timeout),
-                                       ssl=False) as resp:
+                async with session.get(
+                    url,
+                    timeout=aiohttp.ClientTimeout(total=self.timeout),
+                    ssl=False,
+                    headers={"Host": info.domain},
+                    allow_redirects=False,
+                ) as resp:
                     headers = resp.headers
                     if "Public-Key-Pins" in headers or "Public-Key-Pins-Report-Only" in headers:
                         info.has_hpkp = True
@@ -419,7 +457,12 @@ class CertificateAnalyzer:
                 ctx.verify_mode = ssl.CERT_NONE
                 ctx.minimum_version = version_enum
                 ctx.maximum_version = version_enum
-                conn = asyncio.open_connection(info.domain, info.port, ssl=ctx)
+                conn = asyncio.open_connection(
+                    info.connect_ip or info.domain,
+                    info.port,
+                    ssl=ctx,
+                    server_hostname=info.domain,
+                )
                 reader, writer = await asyncio.wait_for(conn, timeout=3)
                 writer.close()
                 await writer.wait_closed()

--- a/packages/scanner/nis2scan/legal.py
+++ b/packages/scanner/nis2scan/legal.py
@@ -5,9 +5,11 @@
 Regional and Legal Compliance Checks
 Validates security.txt, Italian P.IVA, Privacy Policy, Cookie Banners
 """
+import ipaddress
 import re
 import logging
 from typing import Optional, Dict, Any
+from urllib.parse import urlparse
 
 try:
     from playwright.async_api import async_playwright
@@ -16,6 +18,43 @@ except ImportError:
     PLAYWRIGHT_AVAILABLE = False
 
 logger = logging.getLogger("nis2scan")
+
+# Internal/metadata hostnames Playwright must never be steered toward.
+_BLOCKED_HOSTNAMES = {
+    "localhost",
+    "localhost.localdomain",
+    "metadata",
+    "metadata.google.internal",
+    "169.254.169.254",
+    "kubernetes",
+    "kubernetes.default",
+}
+
+
+def _is_blocked_host(hostname: str) -> bool:
+    """True for internal/metadata names or private/reserved IP literals.
+
+    Used to (a) refuse to pin Playwright at a non-public IP and (b) abort any
+    sub-resource request to an obviously-internal host while rendering.
+    """
+    if not hostname:
+        return True
+    h = hostname.strip().lower().rstrip(".")
+    if h in _BLOCKED_HOSTNAMES:
+        return True
+    try:
+        ip = ipaddress.ip_address(h)
+    except ValueError:
+        return False  # a normal public hostname — allowed
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
 
 class LegalChecker:
     """Handles regional/legal compliance checks"""
@@ -94,27 +133,70 @@ class LegalChecker:
 
         return result
 
-    async def _check_with_playwright(self, url: str) -> Dict[str, Any]:
+    async def _check_with_playwright(
+        self, url: str, pinned_ip: Optional[str] = None
+    ) -> Dict[str, Any]:
         """
         Fallback: Use Playwright to render the page and check for compliance.
+
+        SSRF: Chromium re-resolves the FQDN at navigation time, so without
+        pinning a DNS rebind could send the render to an internal address. We
+        require the API-validated `pinned_ip` and force Chromium to map the
+        target host to it (``--host-resolver-rules``), and abort any sub-resource
+        request to an internal host. If we cannot pin safely, we skip the
+        dynamic check rather than navigate via uncontrolled DNS.
         """
         if not PLAYWRIGHT_AVAILABLE:
             logger.warning("Playwright not installed. Skipping dynamic check.")
             return {}
 
-        logger.info(f"Starting Playwright dynamic check for {url}")
+        host = urlparse(url).hostname or ""
+        if not host or _is_blocked_host(host):
+            logger.warning("Skipping Playwright dynamic check for unsafe host: %s", host)
+            return {}
+        if not pinned_ip or _is_blocked_host(pinned_ip):
+            # No validated public IP to pin to — refuse to let Chromium resolve
+            # the host itself (DNS-rebinding risk).
+            logger.warning(
+                "Skipping Playwright dynamic check for %s: no safe pinned IP", host
+            )
+            return {}
+
+        logger.info(
+            f"Starting Playwright dynamic check for {url} (pinned {host} -> {pinned_ip})"
+        )
         try:
             async with async_playwright() as p:
-                # Launch browser (chromium is usually fine)
-                # We assume 'playwright install' has been run
+                # We assume 'playwright install' has been run.
                 try:
-                    browser = await p.chromium.launch(headless=True)
+                    browser = await p.chromium.launch(
+                        headless=True,
+                        # Pin the target host to the validated IP for every port,
+                        # so navigation cannot be rebinded to an internal address.
+                        args=[f"--host-resolver-rules=MAP {host} {pinned_ip}"],
+                    )
                 except Exception as e:
                     logger.error(f"Failed to launch Playwright browser: {e}. Did you run 'playwright install'?")
                     return {}
 
-                # Create a new page and ignore HTTPS errors (common when scanning IPs or internal sites)
+                # New page; ignore HTTPS errors (the pinned host may serve an
+                # IP-mismatched cert). Downloads are off by default.
                 page = await browser.new_page(ignore_https_errors=True)
+
+                # Defense in depth: abort any request to an internal host — e.g.
+                # a malicious page embedding <img src="http://169.254.169.254/">,
+                # which uses an IP literal and so bypasses host-resolver-rules.
+                async def _guard(route):
+                    try:
+                        req_host = urlparse(route.request.url).hostname or ""
+                        if _is_blocked_host(req_host):
+                            await route.abort()
+                        else:
+                            await route.continue_()
+                    except Exception:
+                        await route.abort()
+
+                await page.route("**/*", _guard)
 
                 # Go to URL with timeout
                 try:
@@ -143,7 +225,9 @@ class LegalChecker:
             logger.error(f"Playwright check failed: {e}")
             return {}
 
-    async def analyze_page(self, url: str, html_body: str) -> Dict[str, Any]:
+    async def analyze_page(
+        self, url: str, html_body: str, pinned_ip: Optional[str] = None
+    ) -> Dict[str, Any]:
         """
         Run all legal checks on a page.
         Implements Multi-Fallback:
@@ -177,7 +261,7 @@ class LegalChecker:
 
         if needs_fallback and PLAYWRIGHT_AVAILABLE:
             logger.info(f"Static analysis insufficient for {url}. Attempting dynamic analysis.")
-            dynamic_result = await self._check_with_playwright(url)
+            dynamic_result = await self._check_with_playwright(url, pinned_ip=pinned_ip)
 
             if dynamic_result:
                 # Merge results - prefer dynamic if found

--- a/packages/scanner/nis2scan/scanner.py
+++ b/packages/scanner/nis2scan/scanner.py
@@ -151,10 +151,16 @@ class Scanner:
             # We want to inspect SSL separately or just ignore errors here to get headers
             connector = aiohttp.TCPConnector(ssl=False)
             async with aiohttp.ClientSession(connector=connector, timeout=aiohttp.ClientTimeout(total=self.timeout)) as session:
-                async with session.get(url, headers={"Host": host_header}) as resp:
+                async with session.get(url, headers={"Host": host_header}, allow_redirects=False) as resp:
                     result['status'] = resp.status
                     result['headers'] = dict(resp.headers)
-                    result['redirects'] = [str(r.url) for r in resp.history]
+                    # SSRF: do NOT follow redirects — a 3xx Location could point at
+                    # an internal host / metadata endpoint that aiohttp would
+                    # re-resolve (bypassing the pinned IP). Record where it *would*
+                    # have gone for visibility instead of following it.
+                    result['redirects'] = []
+                    if 'Location' in resp.headers:
+                        result['redirect_location'] = resp.headers.get('Location')
                     # Check security headers
                     result['missing_headers'] = []
                     for h in ['Strict-Transport-Security', 'Content-Security-Policy', 'X-Frame-Options']:
@@ -231,7 +237,11 @@ class Scanner:
                         if port not in [80, 443]:
                             legal_url += f":{port}"
                         legal_url += "/"
-                        result['legal'] = await self.legal_checker.analyze_page(legal_url, body)
+                        # Pass the pinned IP so Playwright resolves the FQDN to the
+                        # same validated address (no DNS rebinding at render time).
+                        result['legal'] = await self.legal_checker.analyze_page(
+                            legal_url, body, pinned_ip=ip
+                        )
 
                     # Secrets detection
                     result['secrets'] = self.secrets_detector.scan_content(body, url)
@@ -240,14 +250,14 @@ class Scanner:
                     # We check /.well-known/security.txt relative to root
                     try:
                         sec_url = f"{schema}://{ip}:{port}/.well-known/security.txt"
-                        async with session.get(sec_url, headers={"Host": host_header}) as sec_resp:
+                        async with session.get(sec_url, headers={"Host": host_header}, allow_redirects=False) as sec_resp:
                             if sec_resp.status == 200:
                                 result['security_txt_found'] = True
                                 result['security_txt_url'] = sec_url
                             else:
                                 # Try fallback /security.txt
                                 sec_url_alt = f"{schema}://{ip}:{port}/security.txt"
-                                async with session.get(sec_url_alt, headers={"Host": host_header}) as sec_resp_alt:
+                                async with session.get(sec_url_alt, headers={"Host": host_header}, allow_redirects=False) as sec_resp_alt:
                                     if sec_resp_alt.status == 200:
                                         result['security_txt_found'] = True
                                         result['security_txt_url'] = sec_url_alt
@@ -259,10 +269,14 @@ class Scanner:
                     for sensitive_path in ['/.git/HEAD', '/.env']:
                         try:
                             sens_url = f"{schema}://{ip}:{port}{sensitive_path}"
-                            async with session.get(sens_url, headers={"Host": host_header}) as sens_resp:
+                            async with session.get(sens_url, headers={"Host": host_header}, allow_redirects=False) as sens_resp:
                                 if sens_resp.status == 200:
-                                    # Verify content to avoid false positives (e.g. custom 404 pages returning 200)
-                                    content = await sens_resp.text()
+                                    # Verify content to avoid false positives (e.g. custom 404 pages returning 200).
+                                    # Cap the read at 64KB so a malicious server streaming a huge body to
+                                    # /.env or /.git/HEAD cannot OOM the worker — the marker strings we
+                                    # look for are tiny and sit at the very start of the file.
+                                    raw = await sens_resp.content.read(64 * 1024)
+                                    content = raw.decode('utf-8', errors='ignore')
                                     if sensitive_path == '/.git/HEAD' and 'ref: refs/' in content:
                                         result['sensitive_files'].append(sensitive_path)
                                     elif sensitive_path == '/.env' and '=' in content:


### PR DESCRIPTION
Remediates 5 findings from the draconian security review: a quick-win authz gap, a deploy defect, the SSRF cluster, and an adjacent DoS cap. Two commits, grouped by theme.

## Findings fixed

### H3 — viewer could trigger scans / edit schedules (privilege escalation + DoS)
`POST /schedules/{id}/run`, `PATCH`, `DELETE` had no role gate (only `create` did). A read-only viewer could enqueue unbounded Celery scan jobs and rewrite/delete other users' schedules. Now: run/update → `admin|auditor`, delete → `admin`.

### H4 — prod Celery missing `CELERY_WORKER=1` (silent prod outage)
Without it, `app.database` uses a pooled async engine instead of `NullPool`; after the first task a pooled asyncpg connection bound to the prior (closed) loop is reused → *"Future attached to a different loop"*, silently stopping scans, scheduled compliance scans, reports and incident-deadline alerts. Set on `celery-worker` + `celery-beat` (matches the dev compose).

### H1 — SSRF in the certificate router
`/certificates/check` + `/bulk-check` analyzed attacker-controlled `host:port` with **no** SSRF guard — the only router bypassing the IP-pinning defense, and it echoed `str(e)` (open/closed oracle). Now:
- `validate_domain_pinned()` rejects private/metadata/blocked/malformed hosts (422, **generic** message);
- TLS **port allowlist** (blocks 22/3306/6379/RDP…);
- `require_role(admin|auditor)` + per-endpoint rate limits;
- the validated **pinned IP** is passed to the analyzer, which connects to it with `server_hostname=domain` → closes the DNS-rebinding TOCTOU.

### H2 — scanner SSRF (DNS rebinding + redirect-following)
- `check_http` followed redirects by default → a 302 to an internal host was followed/re-resolved. `allow_redirects=False` on all sub-requests (Location recorded for visibility).
- The Playwright legal checker navigated the FQDN, letting Chromium re-resolve it. Pin via `--host-resolver-rules=MAP <host> <pinned_ip>`, abort sub-resource requests to internal hosts, and **skip** the dynamic check when no safe IP is available (fail-safe).

### M6 — unbounded body read (worker OOM)
Sensitive-file check (`/.env`, `/.git/HEAD`) read the full response; capped at 64KB.

## Verification
- `ruff` + `py_compile` clean on all touched files.
- Scanner suite **10/10** (no regression on `resolve_target`/`scan_ip`/legal-static).
- API cert router imports with no circular-import; all 3 routes carry the role gate; port allowlist asserted.
- `_is_blocked_host` and `analyze(pinned_ip=)` asserted at runtime.

### Not exercised end-to-end (no live stack here)
A real TLS handshake to a pinned IP and the Playwright render-with-pin were **not** run (no DB/network/browsers in this environment). The security properties are structurally and API-correct (`server_hostname`, `host-resolver-rules` are documented params), but the functional happy-path is reasoned, not executed. **A live scan is recommended before merge.**

## Behavior changes (intentional)
- Certificate endpoints now require `admin|auditor`, are rate-limited, and accept TLS ports only.
- The scanner no longer follows HTTP redirects (deep body analysis on a redirecting `:80` is still captured on the separate `:443` scan).

## Known residual
A Playwright sub-resource to a *public hostname* that resolves to a private IP is not blocked (full closure needs async DNS validation in the route guard). The primary navigation vector is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
