### PR TITLE
security: refuse Celery worker boot on SUPERUSER/BYPASSRLS role in prod (H5, partial)

### DIFF
--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -241,9 +241,24 @@ async def setup_row_level_security() -> None:
             "RLS: tenant_isolation policies verified on %d tables.", len(tenant_tables)
         )
 
-    # Defence-in-depth check: if the application's Postgres role is a
-    # SUPERUSER (or has BYPASSRLS), RLS policies are bypassed for this role.
-    # In production the API refuses to start unless RLS_SUPERUSER_OK=1 is set.
+    # Defence-in-depth: refuse to run with a SUPERUSER/BYPASSRLS role in prod
+    # (shared with the Celery worker boot guard — see assert_db_role_rls_safe).
+    await assert_db_role_rls_safe()
+
+
+async def assert_db_role_rls_safe() -> None:
+    """Refuse to run on a SUPERUSER/BYPASSRLS Postgres role in production.
+
+    If the app's Postgres role is SUPERUSER or has BYPASSRLS, every RLS policy
+    is decorative for that role and tenant isolation rests on application-layer
+    org_id filters ONLY. In production we refuse to start unless
+    RLS_SUPERUSER_OK=1 is set. Shared by the API lifespan
+    (setup_row_level_security) and the Celery worker boot guard
+    (tasks.celery_app) so both processes enforce the same posture — pre-fix the
+    worker had NO guard and silently ran cross-tenant queries under superuser.
+    """
+    if not IS_POSTGRES:
+        return
     try:
         async with engine.connect() as conn:
             result = await conn.execute(

--- a/packages/api/app/tasks/celery_app.py
+++ b/packages/api/app/tasks/celery_app.py
@@ -1,9 +1,14 @@
 # Copyright (c) 2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 # NIS2 Compliance Platform — https://github.com/fabriziosalmi/nis2-public
+import logging
+
 from celery import Celery
+from celery.signals import worker_init
 
 from app.config import settings
+
+logger = logging.getLogger(__name__)
 
 celery_app = Celery(
     "nis2",
@@ -83,3 +88,29 @@ from app.tasks import scan_tasks  # noqa: E402,F401
 from app.tasks import report_tasks  # noqa: E402,F401
 from app.tasks import cleanup_tasks  # noqa: E402,F401
 from app.tasks import incident_tasks  # noqa: E402,F401
+
+
+@worker_init.connect
+def _enforce_rls_role(**_kwargs) -> None:
+    """Boot guard: refuse to start a Celery worker on a SUPERUSER/BYPASSRLS DB
+    role in production, mirroring the API's startup check
+    (database.assert_db_role_rls_safe).
+
+    The worker runs raw cross-tenant queries with no per-request RLS context, so
+    a superuser/BYPASSRLS role here silently defeats tenant isolation — and
+    pre-fix the worker had NO equivalent of the API's guard. Fires once in the
+    worker's main process (not in beat, which uses a file-based scheduler and
+    never touches Postgres). Set RLS_SUPERUSER_OK=1 to opt out (not recommended).
+    """
+    import asyncio
+    import sys
+
+    from app.database import assert_db_role_rls_safe
+
+    try:
+        asyncio.run(assert_db_role_rls_safe())
+    except RuntimeError as exc:
+        # Hard-stop the worker boot — the same loud, restart-looping failure the
+        # API raises in its lifespan, rather than silently running insecure.
+        logger.error("%s", exc)
+        sys.exit(1)


### PR DESCRIPTION
Partial remediation of **H5** from the draconian security review — the *verifiable* slice. Follow-up to #138.

## What this does
The Celery worker runs raw cross-tenant queries with **no per-request RLS context**. If its Postgres role is SUPERUSER or has BYPASSRLS (the default `nis2` role in the postgres image is a superuser), tenant isolation is silently defeated — and unlike the API (`database.setup_row_level_security`), the worker had **no guard** at all.

- Extracts the API's existing superuser/BYPASSRLS check into a shared `database.assert_db_role_rls_safe()` (API behaviour unchanged).
- Invokes it from a Celery `worker_init` signal. In production the worker now **hard-exits** (restart-loops, loud) unless `RLS_SUPERUSER_OK=1`, instead of running insecure in silence. Mirrors the API's posture exactly.
- Beat is unaffected (file-based scheduler, never touches Postgres).

## What this does NOT do (deferred — needs a live NOBYPASSRLS Postgres to validate)
This makes the worker **refuse** an unsafe role; it does **not** yet make it **work** under a non-superuser role. Full H5 closure also needs:
- per-task RLS context (`set_config('app.current_org_id', …)`) — requires threading `org_id` into the Celery task signatures (chicken-and-egg: `_run_scan` loads the scan before it knows the org);
- a cross-tenant sweep refactor (beat's `check_scheduled_scans`, the incident-deadline sweep, and the `audit_logs` retention purge all read across **all** orgs → 0 rows under FORCE RLS) into per-org loops;
- an init-SQL `NOSUPERUSER NOBYPASSRLS` app role + migration path for existing deployments.

These were scoped out because the acceptance test (flip `DATABASE_URL` to the non-superuser role, confirm scans/sweeps/cleanup/isolation all work) requires a live DB this environment doesn't have.

## Verification
- `ruff` + `py_compile` clean.
- `test_rls_migration.py` **16/16** (the database.py refactor leaves the API path unchanged).
- Worker bootstrap imports clean; `worker_init` guard confirmed connected; `assert_db_role_rls_safe` is async/importable.
- The refusal behaviour against a real superuser role is **not** exercised here (needs live Postgres) — but the logic is byte-identical to the API's existing, test-covered guard; it was only relocated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
