### PR TITLE
security: dedicated DATA_ENCRYPTION_KEY for MFA secrets, no hardcoded-literal fallback (M1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,16 @@ JWT_ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 REFRESH_TOKEN_EXPIRE_DAYS=7
 
+# === Field encryption ===
+# Keys field-level encryption of MFA/TOTP secrets (AES-GCM). Independent of
+# JWT_SECRET. When unset, the key is derived from JWT_SECRET for backward
+# compatibility — fine for HS256. In RS256 mode there is NO JWT_SECRET, so this
+# is REQUIRED in production (the API refuses to start without it).
+# Generate with: openssl rand -base64 32
+# NOTE: changing this on an existing deployment makes already-stored TOTP
+# secrets undecryptable — affected users must re-enroll MFA.
+DATA_ENCRYPTION_KEY=
+
 # === Celery ===
 CELERY_BROKER_URL=redis://redis:6379/1
 CELERY_RESULT_BACKEND=redis://redis:6379/2

--- a/packages/api/app/config.py
+++ b/packages/api/app/config.py
@@ -37,6 +37,14 @@ class Settings(BaseSettings):
     # (with literal \n or as multi-line).
     jwt_private_key: str = ""  # PEM-encoded RSA private key (RS256 signing)
     jwt_public_key: str = ""  # PEM-encoded RSA public key (RS256 verification)
+
+    # Dedicated key for field-level encryption (TOTP/MFA secrets today; other
+    # encrypted columns later). Independent of jwt_secret. When unset, the TOTP
+    # key derives from jwt_secret for backward compatibility with deployments
+    # provisioned before this key existed (fine for HS256). RS256 mode has no
+    # jwt_secret, so production REQUIRES this — see _validate_runtime_config.
+    data_encryption_key: str = ""
+
     access_token_expire_minutes: int = 30
     refresh_token_expire_days: int = 7
     cors_origins: str = ""
@@ -125,6 +133,21 @@ class Settings(BaseSettings):
             )
         elif self.jwt_algorithm != "RS256" and len(self.jwt_secret) < 32:
             problems.append("JWT_SECRET must be at least 32 characters in production.")
+
+        # Field-level encryption key material (TOTP/MFA secrets).
+        # get_totp_encryption_key() uses DATA_ENCRYPTION_KEY, falling back to
+        # JWT_SECRET. Independent of the JWT algorithm: an RS256 deploy has no
+        # JWT_SECRET, so without a dedicated key MFA encryption would silently
+        # key off a hardcoded literal — defeating MFA for anyone with a DB dump.
+        # Require strong material either way; fail closed.
+        totp_key_material = self.data_encryption_key or self.jwt_secret
+        if totp_key_material in _INSECURE_JWT_DEFAULTS or len(totp_key_material) < 32:
+            problems.append(
+                "DATA_ENCRYPTION_KEY must be a strong secret of at least 32 "
+                "characters — it keys field-level MFA/TOTP encryption. In RS256 "
+                "mode there is no JWT_SECRET to fall back on, so it is required. "
+                "Generate with `openssl rand -base64 32`."
+            )
         if not self.cors_origins.strip():
             problems.append(
                 "CORS_ORIGINS must be set explicitly in production "

--- a/packages/api/app/utils/crypto.py
+++ b/packages/api/app/utils/crypto.py
@@ -10,8 +10,21 @@ from app.config import settings
 
 
 def get_totp_encryption_key() -> bytes:
-    """Derive a 32-byte key from settings.jwt_secret."""
-    secret = settings.jwt_secret or "temporary-ephemeral-secret-key-for-mfa"
+    """Derive the 32-byte AES-GCM key for field-level TOTP encryption.
+
+    Prefers the dedicated DATA_ENCRYPTION_KEY; falls back to JWT_SECRET so
+    deployments provisioned before DATA_ENCRYPTION_KEY existed keep the same
+    derived key and their stored secrets stay decryptable. Fails closed when
+    neither is available — it must never derive from a hardcoded literal, which
+    would let anyone with the (public, AGPL) source decrypt MFA seeds from a
+    stolen DB. Production config validation guarantees key material is present.
+    """
+    secret = settings.data_encryption_key or settings.jwt_secret
+    if not secret:
+        raise RuntimeError(
+            "No encryption key for TOTP secrets: set DATA_ENCRYPTION_KEY (or "
+            "JWT_SECRET). Refusing to derive a key from a hardcoded value."
+        )
     return hashlib.sha256(secret.encode()).digest()
 
 

--- a/packages/api/tests/test_data_encryption_key.py
+++ b/packages/api/tests/test_data_encryption_key.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""M1: the field-level TOTP encryption key must never fall back to a hardcoded
+literal, and production must require strong key material regardless of the JWT
+algorithm. Pure-logic — no DB / HTTP / event loop."""
+import hashlib
+from unittest.mock import patch
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+def _gen_keypair() -> tuple[str, str]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    priv = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    ).decode()
+    pub = key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv, pub
+
+
+PRIVATE_PEM, PUBLIC_PEM = _gen_keypair()
+STRONG = "x" * 40  # >= 32 chars, not a placeholder
+
+
+# --- crypto: key derivation ------------------------------------------------
+
+
+def test_totp_key_prefers_data_encryption_key():
+    from app import config
+    from app.utils.crypto import get_totp_encryption_key
+
+    with patch.multiple(
+        config.settings, data_encryption_key="dedicated-" + STRONG, jwt_secret="jwt-" + STRONG
+    ):
+        expected = hashlib.sha256(("dedicated-" + STRONG).encode()).digest()
+        assert get_totp_encryption_key() == expected
+
+
+def test_totp_key_falls_back_to_jwt_secret():
+    """Backward compat: deployments without DATA_ENCRYPTION_KEY keep deriving
+    from JWT_SECRET — same key, so stored secrets stay decryptable."""
+    from app import config
+    from app.utils.crypto import get_totp_encryption_key
+
+    with patch.multiple(config.settings, data_encryption_key="", jwt_secret="jwt-" + STRONG):
+        expected = hashlib.sha256(("jwt-" + STRONG).encode()).digest()
+        assert get_totp_encryption_key() == expected
+
+
+def test_totp_key_fails_closed_with_no_material():
+    """No literal fallback: with neither key set, refuse rather than derive a
+    key from a hardcoded value (the M1 vulnerability)."""
+    from app import config
+    from app.utils.crypto import get_totp_encryption_key
+
+    with patch.multiple(config.settings, data_encryption_key="", jwt_secret=""):
+        with pytest.raises(RuntimeError):
+            get_totp_encryption_key()
+
+
+# --- config validation -----------------------------------------------------
+
+
+def test_hs256_prod_boots_without_data_key():
+    """Existing HS256 deployments (strong JWT_SECRET, no DATA_ENCRYPTION_KEY)
+    must still boot — the TOTP key falls back to JWT_SECRET."""
+    from app.config import Settings
+
+    s = Settings(
+        environment="production",
+        jwt_algorithm="HS256",
+        jwt_secret=STRONG,
+        data_encryption_key="",
+        cors_origins="https://x.example.com",
+    )
+    assert s.jwt_secret == STRONG
+
+
+def test_rs256_prod_requires_data_key():
+    """The M1 vuln: RS256 (no JWT_SECRET) without DATA_ENCRYPTION_KEY must refuse
+    to start instead of keying MFA off a hardcoded literal."""
+    from app.config import Settings
+
+    with pytest.raises(RuntimeError) as exc:
+        Settings(
+            environment="production",
+            jwt_private_key=PRIVATE_PEM,
+            jwt_public_key=PUBLIC_PEM,
+            jwt_secret="",
+            data_encryption_key="",
+            cors_origins="https://x.example.com",
+        )
+    assert "DATA_ENCRYPTION_KEY" in str(exc.value)
+
+
+def test_rs256_prod_boots_with_data_key():
+    from app.config import Settings
+
+    s = Settings(
+        environment="production",
+        jwt_private_key=PRIVATE_PEM,
+        jwt_public_key=PUBLIC_PEM,
+        jwt_secret="",
+        data_encryption_key=STRONG,
+        cors_origins="https://x.example.com",
+    )
+    assert s.jwt_algorithm == "RS256"
+    assert s.data_encryption_key == STRONG
+
+
+def test_rs256_prod_boots_with_strong_jwt_secret_fallback():
+    """Backward compat: an RS256 deploy that set a strong JWT_SECRET (no
+    DATA_ENCRYPTION_KEY) keeps booting — the fallback is secure, not a literal."""
+    from app.config import Settings
+
+    s = Settings(
+        environment="production",
+        jwt_private_key=PRIVATE_PEM,
+        jwt_public_key=PUBLIC_PEM,
+        jwt_secret=STRONG,
+        data_encryption_key="",
+        cors_origins="https://x.example.com",
+    )
+    assert s.jwt_algorithm == "RS256"


### PR DESCRIPTION
Remediates **M1** from the draconian security review.

## The bug
`get_totp_encryption_key()` derived the AES-GCM key for field-level TOTP/MFA encryption from `sha256(jwt_secret)`, falling back to a **hardcoded literal** (`"temporary-ephemeral-secret-key-for-mfa"`) when `jwt_secret` was empty. In RS256 mode — the README-recommended production config — `config.py` skips the `jwt_secret` strength check, so an operator can boot with **no `JWT_SECRET`**. Every user's TOTP seed is then encrypted with a key that is **visible in the public AGPL source**: a stolen DB dump / backup / replica defeats MFA platform-wide — the exact threat field-level encryption is meant to defend.

## The fix
- New dedicated `DATA_ENCRYPTION_KEY` setting, **independent of `jwt_secret`**.
- `get_totp_encryption_key()` prefers it, **falls back to `jwt_secret`** (so existing HS256 deployments keep the *same* derived key — stored secrets stay decryptable), and **fails closed** if neither is set. The hardcoded literal is removed.
- Production config now requires **strong key material (≥ 32 chars) regardless of `jwt_algorithm`**: an RS256 deploy (which has no `jwt_secret`) must set `DATA_ENCRYPTION_KEY`, closing the boot-with-no-key gap.
- `.env.example` documents the key; `test_data_encryption_key.py` adds 7 tests.

## Backward compatibility
- Existing **HS256** deployments (strong `JWT_SECRET`, no `DATA_ENCRYPTION_KEY`) are unaffected — same key, no migration.
- Existing **RS256** deployments that set a strong `JWT_SECRET` also keep booting (secure fallback).
- Only RS256 deployments with **no key material at all** (the vulnerable ones) are forced to set `DATA_ENCRYPTION_KEY`. ⚠️ Those previously encrypted TOTP secrets with the public literal, so affected users must re-enroll MFA after setting the key — documented in `.env.example`.

## Verification
- `ruff` + `py_compile` clean.
- **32/32** tests pass: 7 new (`test_data_encryption_key.py`) + `test_totp_mfa.py` + `test_jwt_rs256.py` regression — no break to existing TOTP encryption or RS256 config.
- Not exercised: a full prod boot with a real RS256 keypair + DB (the config-validation paths are covered by the new unit tests, which construct `Settings(environment="production", …)` directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
