### PR TITLE
security: per-account login lockout with progressive backoff (M3, partial)

### DIFF
--- a/packages/api/app/routers/auth.py
+++ b/packages/api/app/routers/auth.py
@@ -27,6 +27,7 @@ from app.models.password_reset_token import PasswordResetToken
 from app.models.revoked_token import RevokedToken
 from app.models.user import User
 from app.utils.email import get_dev_outbox, send_email
+from app.utils import login_throttle
 import pyotp
 
 from app.schemas.auth import (
@@ -404,16 +405,29 @@ async def login(
     slim: bool = Query(False),
     db: AsyncSession = Depends(get_db),
 ) -> TokenResponse | MFARequiredResponse:
+    # Per-account lockout (M3): IP-independent brute-force / credential-stuffing
+    # defense, complementing the per-IP slowapi limit on this route.
+    locked_for = await login_throttle.seconds_until_unlock(payload.email)
+    if locked_for > 0:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Account temporarily locked after repeated failed logins. "
+            f"Try again in {locked_for}s.",
+            headers={"Retry-After": str(locked_for)},
+        )
+
     result = await db.execute(select(User).where(User.email == payload.email))
     user = result.scalar_one_or_none()
 
     if not user or not user.password_hash:
+        await login_throttle.record_failure(payload.email)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid email or password",
         )
 
     if not pwd_context.verify(payload.password, user.password_hash):
+        await login_throttle.record_failure(payload.email)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid email or password",
@@ -442,10 +456,15 @@ async def login(
                         ",".join(codes_list) if codes_list else None
                     )
             if not recovery_valid:
+                await login_throttle.record_failure(payload.email)
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail="Invalid MFA code",
                 )
+
+    # Full auth success (password + MFA) — clear any accumulated failed-attempt
+    # / lock state for this account.
+    await login_throttle.reset(payload.email)
 
     user.last_login_at = datetime.now(timezone.utc)
     await db.flush()

--- a/packages/api/app/utils/login_throttle.py
+++ b/packages/api/app/utils/login_throttle.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+# NIS2 Compliance Platform — https://github.com/fabriziosalmi/nis2-public
+"""Per-account login throttling with progressive lockout (M3 hardening).
+
+The per-IP slowapi limit on /auth/login is easily diluted across many source
+IPs and, behind a reverse proxy, can collapse to the proxy's own IP. This module
+adds an IP-independent defense: failed attempts are counted per email in Redis,
+and after MAX_FAILED_ATTEMPTS within FAIL_WINDOW_SECONDS the account is locked
+for a progressively longer duration.
+
+Fails OPEN if Redis is unreachable — a Redis outage must never lock every user
+out of the platform (availability > strict throttling for this control).
+
+Tradeoff: an attacker who knows an email can deliberately trip the lockout to
+deny that user service. The lockout is bounded (progressive, capped at 1 h) and
+auto-expires, which is the standard accepted tradeoff for brute-force defense.
+"""
+from __future__ import annotations
+
+import logging
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+MAX_FAILED_ATTEMPTS = 5
+FAIL_WINDOW_SECONDS = 900  # rolling window to accumulate failures (15 min)
+BASE_LOCK_SECONDS = 60  # first lockout duration
+MAX_LOCK_SECONDS = 3600  # cap a single lockout at 1 h
+
+_FAIL_KEY = "login:fail:{email}"
+_LOCK_KEY = "login:lock:{email}"
+_LOCKCOUNT_KEY = "login:lockcount:{email}"
+
+_redis = None
+
+
+def lock_duration(consecutive_lockouts: int) -> int:
+    """Progressive backoff: BASE * 2^(n-1), capped at MAX. Pure → unit-testable."""
+    if consecutive_lockouts < 1:
+        return 0
+    return min(BASE_LOCK_SECONDS * 2 ** (consecutive_lockouts - 1), MAX_LOCK_SECONDS)
+
+
+async def _client():
+    """Lazily create a per-process async Redis client. One event loop per
+    gunicorn worker, so a module-level client is safe here (unlike Celery,
+    which mints a fresh loop per task)."""
+    global _redis
+    if _redis is None:
+        import redis.asyncio as aioredis
+
+        # Short timeouts bound the fail-open latency added to the login path
+        # when Redis is unreachable (~2s instead of a long default).
+        _redis = aioredis.from_url(
+            settings.redis_url,
+            decode_responses=True,
+            socket_connect_timeout=2,
+            socket_timeout=2,
+        )
+    return _redis
+
+
+def _norm(email: str) -> str:
+    return (email or "").strip().lower()
+
+
+async def seconds_until_unlock(email: str) -> int:
+    """Remaining lock time for this account (0 if not locked). Fail-open."""
+    try:
+        ttl = await (await _client()).ttl(_LOCK_KEY.format(email=_norm(email)))
+        return ttl if ttl and ttl > 0 else 0
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("login_throttle: Redis unavailable (lock check): %s", exc)
+        return 0
+
+
+async def record_failure(email: str) -> int:
+    """Count a failed attempt and lock the account when the threshold is crossed.
+
+    Returns the lock duration just applied (0 if not yet locked). Fail-open.
+    """
+    e = _norm(email)
+    try:
+        r = await _client()
+        fails = await r.incr(_FAIL_KEY.format(email=e))
+        if fails == 1:
+            await r.expire(_FAIL_KEY.format(email=e), FAIL_WINDOW_SECONDS)
+        if fails >= MAX_FAILED_ATTEMPTS:
+            lockcount = await r.incr(_LOCKCOUNT_KEY.format(email=e))
+            await r.expire(_LOCKCOUNT_KEY.format(email=e), MAX_LOCK_SECONDS * 4)
+            duration = lock_duration(lockcount)
+            await r.set(_LOCK_KEY.format(email=e), "1", ex=duration)
+            await r.delete(_FAIL_KEY.format(email=e))  # reset the window post-lock
+            logger.warning(
+                "login_throttle: account locked email=%s for %ds (lockout #%d)",
+                e,
+                duration,
+                lockcount,
+            )
+            return duration
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("login_throttle: Redis unavailable (record failure): %s", exc)
+        return 0
+
+
+async def reset(email: str) -> None:
+    """Clear failure/lock state after a successful login. Fail-open."""
+    e = _norm(email)
+    try:
+        r = await _client()
+        # Clear the failure window and any active lock so the user can proceed.
+        # Deliberately KEEP the lockcount (escalation memory, TTL-bounded) so a
+        # lock -> unlock -> re-lock attack escalates instead of resetting to BASE.
+        await r.delete(
+            _FAIL_KEY.format(email=e),
+            _LOCK_KEY.format(email=e),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("login_throttle: Redis unavailable (reset): %s", exc)

--- a/packages/api/tests/test_login_throttle.py
+++ b/packages/api/tests/test_login_throttle.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""M3: per-account login lockout. Pure-logic + fake-Redis — no server needed."""
+import asyncio
+
+import pytest
+
+from app.utils import login_throttle
+
+
+class FakeRedis:
+    """Minimal async Redis stand-in covering the ops login_throttle uses."""
+
+    def __init__(self):
+        self.vals: dict[str, object] = {}
+        self.ttls: dict[str, int] = {}
+
+    async def incr(self, key):
+        self.vals[key] = int(self.vals.get(key, 0)) + 1
+        return self.vals[key]
+
+    async def expire(self, key, seconds):
+        self.ttls[key] = seconds
+        return True
+
+    async def set(self, key, value, ex=None):
+        self.vals[key] = value
+        if ex is not None:
+            self.ttls[key] = ex
+        return True
+
+    async def ttl(self, key):
+        if key not in self.vals and key not in self.ttls:
+            return -2  # redis convention: key does not exist
+        return self.ttls.get(key, -1)
+
+    async def delete(self, *keys):
+        n = 0
+        for k in keys:
+            if k in self.vals:
+                del self.vals[k]
+                n += 1
+            self.ttls.pop(k, None)
+        return n
+
+
+@pytest.fixture(autouse=True)
+def fake_redis(monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr(login_throttle, "_redis", fake)
+    return fake
+
+
+def test_lock_duration_progression():
+    assert login_throttle.lock_duration(0) == 0
+    assert login_throttle.lock_duration(1) == login_throttle.BASE_LOCK_SECONDS
+    assert login_throttle.lock_duration(2) == login_throttle.BASE_LOCK_SECONDS * 2
+    assert login_throttle.lock_duration(3) == login_throttle.BASE_LOCK_SECONDS * 4
+    # capped
+    assert login_throttle.lock_duration(99) == login_throttle.MAX_LOCK_SECONDS
+
+
+def test_not_locked_initially():
+    assert asyncio.run(login_throttle.seconds_until_unlock("a@b.com")) == 0
+
+
+def test_locks_after_threshold():
+    async def scenario():
+        email = "victim@example.com"
+        for _ in range(login_throttle.MAX_FAILED_ATTEMPTS - 1):
+            assert await login_throttle.record_failure(email) == 0
+        assert await login_throttle.seconds_until_unlock(email) == 0
+        # the threshold failure locks the account
+        assert (
+            await login_throttle.record_failure(email)
+            == login_throttle.BASE_LOCK_SECONDS
+        )
+        assert (
+            await login_throttle.seconds_until_unlock(email)
+            == login_throttle.BASE_LOCK_SECONDS
+        )
+
+    asyncio.run(scenario())
+
+
+def test_repeat_lockout_escalates():
+    async def scenario():
+        email = "repeat@example.com"
+        for _ in range(login_throttle.MAX_FAILED_ATTEMPTS):
+            await login_throttle.record_failure(email)
+        await login_throttle.reset(email)  # window cleared but lockcount persists
+        # second lockout cycle must be longer (progressive backoff)
+        last = 0
+        for _ in range(login_throttle.MAX_FAILED_ATTEMPTS):
+            last = await login_throttle.record_failure(email)
+        assert last == login_throttle.BASE_LOCK_SECONDS * 2
+
+    asyncio.run(scenario())
+
+
+def test_reset_clears_lock():
+    async def scenario():
+        email = "u@example.com"
+        for _ in range(login_throttle.MAX_FAILED_ATTEMPTS):
+            await login_throttle.record_failure(email)
+        assert await login_throttle.seconds_until_unlock(email) > 0
+        await login_throttle.reset(email)
+        assert await login_throttle.seconds_until_unlock(email) == 0
+
+    asyncio.run(scenario())
+
+
+def test_email_normalized():
+    async def scenario():
+        for _ in range(login_throttle.MAX_FAILED_ATTEMPTS):
+            await login_throttle.record_failure("Victim@Example.COM")
+        # a differently-cased / padded form maps to the same locked account
+        assert await login_throttle.seconds_until_unlock("  victim@example.com ") > 0
+
+    asyncio.run(scenario())
+
+
+def test_fails_open_when_redis_unavailable(monkeypatch):
+    class BrokenRedis:
+        async def incr(self, *a):
+            raise RuntimeError("redis down")
+
+        async def ttl(self, *a):
+            raise RuntimeError("redis down")
+
+        async def expire(self, *a):
+            raise RuntimeError("redis down")
+
+        async def set(self, *a, **k):
+            raise RuntimeError("redis down")
+
+        async def delete(self, *a):
+            raise RuntimeError("redis down")
+
+    monkeypatch.setattr(login_throttle, "_redis", BrokenRedis())
+    # Every entry point must fail open (no exception, never locks).
+    assert asyncio.run(login_throttle.seconds_until_unlock("x@y.com")) == 0
+    assert asyncio.run(login_throttle.record_failure("x@y.com")) == 0
+    asyncio.run(login_throttle.reset("x@y.com"))  # must not raise


### PR DESCRIPTION
Remediates the core of **M3** from the security review: adds a per-account login lockout.

## The bug
The only throttle on `/auth/login` was `@limiter.limit("10/minute")` keyed on the client IP via `get_remote_address`. Three problems:
- Behind Caddy the API sees the **proxy's** IP, so every login shares one bucket (undifferentiated), and credential stuffing across many real IPs is unthrottled.
- With `gunicorn -w 4` the in-memory bucket is **per-worker**, so the effective limit is ~4×.
- There was **no per-account** failed-attempt counter at all.

## The fix (shipped here)
`app/utils/login_throttle.py` — IP-independent, per-email lockout backed by Redis:
- Counts failed attempts per email; after **5 failures within 15 min** the account locks for a **progressive** duration (60s base, ×2 each repeat lockout, capped at 1h).
- Wired into `/auth/login`: a locked account returns **429 + `Retry-After`**; bad password / unknown email / bad MFA all record a failure; a full success (password **and** MFA) clears the window + lock.
- **Fails open** if Redis is unreachable — an outage must never lock every user out.
- Escalation memory (`lockcount`) deliberately survives a successful login (TTL-bounded) so a *lock → unlock → re-lock* attack escalates instead of resetting to base.

## Deferred (documented, needs live validation)
The IP-side improvements from the review are **coupled and deployment-/version-sensitive**, so they are intentionally *not* in this PR:
- **Recovering the real client IP** (trusting `X-Forwarded-For` from the proxy) is version- and topology-specific; trusting it wrong enables IP spoofing of the rate limit / audit log. Needs the operator's proxy config + a live check of uvicorn's forwarded-hop handling.
- **Shared Redis storage for slowapi** can't ship before that: while `get_remote_address` collapses to Caddy's IP, a *shared* `10/minute` bucket would become a **platform-wide** login limit (a DoS). The two must land together, after the real-IP fix is validated live.

The per-account lockout above is the robust, IP-independent defense and stands on its own.

## Tradeoff (documented in code)
An attacker who knows an email can deliberately trip the lockout to deny that user service. The lockout is bounded (progressive, capped at 1h) and auto-expires — the standard accepted tradeoff for brute-force defense.

## Verification
- `ruff` + `py_compile` clean.
- **39/39** tests: 7 new (`test_login_throttle.py`, incl. fail-open, escalation, email normalization) + `test_totp_mfa` + `test_jwt_rs256` + `test_data_encryption_key` regression.
- Not exercised end-to-end: the `/auth/login` HTTP path against a live Redis (the lockout logic is covered by the fake-Redis unit tests; the wiring is a straight-line call that fails open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
