### PR TITLE
security: loopback-bind dev ports + rate-limit/gate LLM remediation (M4, M5)

### DIFF
--- a/infra/docker/docker-compose.dev.yml
+++ b/infra/docker/docker-compose.dev.yml
@@ -8,7 +8,10 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-nis2}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-nis2secret}
       POSTGRES_DB: ${POSTGRES_DB:-nis2}
-    ports: ["5433:5432"]
+    # Security: bind to loopback only. `make dev` on an untrusted LAN must not
+    # expose Postgres (default creds) to the network — and Docker's iptables
+    # rules bypass a host firewall, so the explicit 127.0.0.1 is the guard.
+    ports: ["127.0.0.1:5433:5432"]
     volumes: [pgdata:/var/lib/postgresql/data]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U nis2"]
@@ -49,7 +52,8 @@ services:
       # mid-debug); for prod a real shared filesystem or object
       # store is the right answer.
       - reports-data:/tmp/nis2-reports
-    ports: ["8000:8000"]
+    # Security: loopback-only (see postgres). Off-host access is opt-in.
+    ports: ["127.0.0.1:8000:8000"]
     env_file: ../../.env
     environment:
       ENVIRONMENT: development
@@ -134,7 +138,8 @@ services:
       - ../../packages/web:/app
       - /app/node_modules
       - /app/.next
-    ports: ["8077:3000"]
+    # Security: loopback-only (see postgres). Off-host access is opt-in.
+    ports: ["127.0.0.1:8077:3000"]
     env_file: ../../.env
     environment:
       # Browser-side: where the user's browser reaches the API directly.

--- a/packages/api/app/routers/remediation.py
+++ b/packages/api/app/routers/remediation.py
@@ -10,13 +10,14 @@ import os
 import uuid
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.dependencies import get_current_org
+from app.dependencies import get_current_org, require_role
+from app.routers.auth import limiter  # share the single Limiter instance
 from app.models.finding import Finding
 from app.models.membership import Membership
 from app.models.user import User
@@ -143,9 +144,14 @@ class ExplainRequest(BaseModel):
     )
 
 
-@router.post("/explain/{finding_id}")
+@router.post(
+    "/explain/{finding_id}",
+    dependencies=[Depends(require_role("admin", "auditor"))],
+)
+@limiter.limit("10/minute")
 async def explain_finding(
     finding_id: uuid.UUID,
+    request: Request,
     payload: ExplainRequest = ExplainRequest(),
     current_org: tuple[User, Membership] = Depends(get_current_org),
     db: AsyncSession = Depends(get_db),


### PR DESCRIPTION
Two small hardening fixes from the security review, closing out the quick Medium items.

## M4 — dev compose published ports to `0.0.0.0`
`make dev` exposed **Postgres (5433)**, the **API (8000)** and the **web UI (8077)** on all interfaces. On an untrusted LAN that puts Postgres (default creds) and the app one hop from anyone on the network — and Docker's iptables rules **bypass a host firewall**, so a host-level block doesn't help. Bound all three to `127.0.0.1`; off-host access is now opt-in. (Redis already had its host port removed in v2.5.6.)

## M5 — LLM remediation endpoint had no rate limit or role gate
`POST /remediation/explain/{finding_id}` calls an LLM (OpenAI, `max_tokens=2000`) with **no `@limiter.limit` and no `require_role`**, so any authenticated user — including a read-only **viewer** — could loop it to burn the operator's OpenAI billing. Added `require_role('admin','auditor')` + `@limiter.limit("10/minute")`. (The `/certificates/*` half of M5 already shipped in #138.)

## Verification
- `ruff` + `py_compile` clean.
- Dev compose parses; **every published host port is `127.0.0.1`-bound** (asserted).
- `remediation` router imports with no circular import; `/explain` confirmed role-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
