### PR TITLE
security: return 409 instead of 500 on slug/email insert races (M7)

### DIFF
--- a/packages/api/app/routers/auth.py
+++ b/packages/api/app/routers/auth.py
@@ -16,6 +16,7 @@ from passlib.context import CryptContext
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
@@ -241,7 +242,14 @@ async def register(
         full_name=payload.full_name,
     )
     db.add(user)
-    await db.flush()
+    try:
+        await db.flush()
+    except IntegrityError:
+        # Concurrent registration with the same email raced past the pre-check.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Email already registered",
+        )
 
     base_slug = _slugify(payload.org_name)
     slug = base_slug
@@ -257,7 +265,14 @@ async def register(
 
     org = Organization(name=payload.org_name, slug=slug)
     db.add(org)
-    await db.flush()
+    try:
+        await db.flush()
+    except IntegrityError:
+        # Lost the check-then-insert race on the slug — surface a clean 409.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="An organization with a conflicting name was just created; please retry.",
+        )
 
     # Set the session org_id so that inserting into the RLS-protected memberships table is allowed
     await _set_session_org_id(db, org.id)

--- a/packages/api/app/routers/organizations.py
+++ b/packages/api/app/routers/organizations.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -91,7 +92,16 @@ async def create_organization(
     #    admin to manage it.
     org = Organization(name=payload.name, slug=slug)
     db.add(org)
-    await db.flush()
+    try:
+        await db.flush()
+    except IntegrityError:
+        # Lost the check-then-insert race on the slug — another request created
+        # the same slug between our uniqueness check and this flush. get_db rolls
+        # the request transaction back; surface a clean 409 instead of a 500.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="An organization with a conflicting name was just created; please retry.",
+        )
 
     membership = Membership(
         user_id=current_user.id,


### PR DESCRIPTION
Remediates **M7** from the security review.

## The bug
`create_organization` (organizations.py) and `register` (auth.py) both **check** slug/email uniqueness with a `SELECT`, then **insert**. A concurrent request can insert the same value in that TOCTOU window, so the race loser's `flush()` hits the `UNIQUE` constraint. With no handler, that bubbles up as an HTTP **500 with a raw `IntegrityError`** instead of a clean conflict response. (Finding impact: error-handling quality — no data corruption or cross-tenant leak.)

## The fix
Wrap each create+flush in `try/except IntegrityError` and surface a clean **409**:
- `register`: email race → `409 "Email already registered"`; org-slug race → `409 "…please retry"`.
- `create_organization`: org-slug race → `409 "…please retry"`.

`get_db` already rolls the request transaction back on the propagated `HTTPException`, so the failed insert leaves no partial state. The existing optimistic pre-check still suffixes **non-concurrent** duplicate names (`acme`, `acme-1`, …); only the rare genuine race now falls through to the 409 instead of a 500.

## Why not auto-retry with a savepoint?
The review suggested "409 **or** -1 suffix retry". A suffix-retry-on-race needs a SQL `SAVEPOINT` (`begin_nested`) to recover the aborted transaction, whose behavior differs between Postgres and the SQLite test backend and can't be verified here without a live concurrent Postgres. The 409 is the simpler, correct, fully-verifiable choice and is explicitly one of the accepted remediations.

## Verification
- `ruff` + `py_compile` clean.
- **72/72** pre-existing auth-importing tests pass (`test_jwt_rs256`, `test_totp_mfa`, `test_cron_validator`) — the happy path (flush succeeds, no exception) is unchanged.
- Not exercised: the actual concurrent-race → 409 path (needs two simultaneous requests against a live Postgres). The change is a localized `try/except` around an existing flush; the non-race path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
