### PR TITLE
security: disclose+gate OpenAI egress, fix Redis env URLs & Art.23 deadline (L7, L8, L13)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,10 @@ POSTGRES_PASSWORD=CHANGE_ME_DB_PASSWORD
 POSTGRES_DB=nis2
 
 # === Redis ===
-REDIS_URL=redis://redis:6379/0
+# Production runs `redis-server --requirepass $REDIS_PASSWORD`, so the URL MUST
+# embed the same password (userless `:password@host`). Keep it in sync with
+# REDIS_PASSWORD below or the stack never goes healthy (Redis returns NOAUTH).
+REDIS_URL=redis://:CHANGE_ME_REDIS_PASSWORD@redis:6379/0
 # Required by docker-compose.prod.yml (redis-server --requirepass).
 REDIS_PASSWORD=CHANGE_ME_REDIS_PASSWORD
 
@@ -49,8 +52,8 @@ REFRESH_TOKEN_EXPIRE_DAYS=7
 DATA_ENCRYPTION_KEY=
 
 # === Celery ===
-CELERY_BROKER_URL=redis://redis:6379/1
-CELERY_RESULT_BACKEND=redis://redis:6379/2
+CELERY_BROKER_URL=redis://:CHANGE_ME_REDIS_PASSWORD@redis:6379/1
+CELERY_RESULT_BACKEND=redis://:CHANGE_ME_REDIS_PASSWORD@redis:6379/2
 
 # === NextAuth ===
 # Generate with: openssl rand -base64 32
@@ -59,6 +62,17 @@ NEXTAUTH_SECRET=CHANGE_ME_RUN_openssl_rand_base64_32
 # === API ===
 API_URL=http://localhost:8000
 NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# === AI remediation (OPTIONAL — off by default) ===
+# The "Explain finding" copilot can call a local LLM (Ollama/LM Studio) or
+# OpenAI. The local LLM stays on-prem. OpenAI egress is DISABLED unless you set
+# ENABLE_OPENAI=true — setting only OPENAI_API_KEY is no longer enough.
+# PRIVACY: enabling OpenAI sends finding text (which may contain internal
+# hostnames, leaked secrets, incidental PII) to api.openai.com in the USA — a
+# transborder flow you must disclose in your privacy notice (docs/privacy.md §7.3).
+LLM_API_URL=http://localhost:1234/v1
+OPENAI_API_KEY=
+ENABLE_OPENAI=false
 
 # === CORS ===
 # REQUIRED in production. Comma-separated allow-list, no wildcards.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -131,8 +131,9 @@ The scanner makes **direct DNS, TLS, HTTP, and TCP connections to the targets th
 | `crt.sh` (Sectigo) | Certificate Transparency log lookup for subdomain enumeration | the domain being scanned | Sectigo Limited (USA / UK) | scanner → crt.sh over HTTPS |
 | Public DNS resolvers (system-configured) | Name resolution for scan targets | the domain being scanned | the deployer's resolver chain (often Cloudflare 1.1.1.1, Google 8.8.8.8, ISP) | OS resolver |
 | Target hosts | TLS / HTTP / port probes | source IP of the scanner pod, scanner User-Agent | the target's operator | direct connection |
+| `api.openai.com` *(only when `ENABLE_OPENAI=true`)* | AI remediation explanations (`POST /remediation/explain`) | the finding's message / target / technical detail — may contain internal hostnames, leaked secrets, incidental PII | OpenAI, L.L.C. (USA) | API → OpenAI over HTTPS |
 
-If your deployment uses a corporate proxy or a dedicated egress IP, replace the rows above accordingly. **No telemetry leaves the platform**: there is no callback to the maintainer, no error-reporting service, no analytics endpoint.
+If your deployment uses a corporate proxy or a dedicated egress IP, replace the rows above accordingly. **No telemetry leaves the platform**: there is no callback to the maintainer, no error-reporting service, no analytics endpoint. The AI remediation copilot is the one *optional* third-party egress — it is **off by default** and only sends data to OpenAI when the operator explicitly sets `ENABLE_OPENAI=true` (see the `api.openai.com` row above and `.env.example`).
 
 ### 7.4 PII captured incidentally by the scanner
 

--- a/packages/api/app/config.py
+++ b/packages/api/app/config.py
@@ -98,6 +98,11 @@ class Settings(BaseSettings):
     # shared / multi-tenant setups. Default 3.
     max_concurrent_reports_per_org: int = 3
 
+    # AI remediation copilot (POST /remediation/explain). OpenAI egress is OFF by
+    # default — OPENAI_API_KEY alone does NOT enable it; ENABLE_OPENAI must be true.
+    # See docs/privacy.md §7.3 (transborder data flow to OpenAI, USA).
+    enable_openai: bool = False
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 
     @model_validator(mode="after")

--- a/packages/api/app/routers/acn.py
+++ b/packages/api/app/routers/acn.py
@@ -196,7 +196,12 @@ async def csirt_emergency_payload(
             "detection_timestamp": detected.isoformat(),
             "early_warning_deadline": (detected + timedelta(hours=24)).isoformat(),
             "notification_deadline": (detected + timedelta(hours=72)).isoformat(),
-            "final_report_deadline": (detected + timedelta(days=30)).isoformat(),
+            # NIS2 Art. 23(4)(d): the final report is due 1 month from the
+            # *notification* (the 72h report), NOT from detection. Was
+            # `detected + 30d`, which told operators it was due ~a month early.
+            "final_report_deadline": (
+                detected + timedelta(hours=72) + timedelta(days=30)
+            ).isoformat(),
             "description": data.what_happened,
             "affected_services": data.affected_services,
             "is_ongoing": data.is_ongoing,

--- a/packages/api/app/routers/remediation.py
+++ b/packages/api/app/routers/remediation.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.database import get_db
 from app.dependencies import get_current_org, require_role
 from app.routers.auth import limiter  # share the single Limiter instance
@@ -225,8 +226,10 @@ Respond in a structured format with clear headings."""
                 exc_info=True,
             )
 
-    # Fallback to OpenAI
-    if not explanation and openai_key:
+    # Fallback to OpenAI — gated behind an explicit opt-in. A configured key is
+    # NOT enough: cloud egress (finding text -> api.openai.com, USA) only fires
+    # when ENABLE_OPENAI=true. See docs/privacy.md §7.3.
+    if not explanation and openai_key and settings.enable_openai:
         try:
             import aiohttp
 


### PR DESCRIPTION
Three quick Low-severity items from the security review (the safe, high-value ones).

## L7 — undisclosed OpenAI egress (privacy / compliance)
The AI remediation copilot (`POST /remediation/explain`) sent finding text — which may contain **internal hostnames, leaked secrets, incidental PII** — to `api.openai.com` (USA) **merely because `OPENAI_API_KEY` was set**. That transborder flow was absent from the privacy notice operators rely on for their RoPA/DPIA.
- **Gated**: egress now requires an explicit `ENABLE_OPENAI=true`; a configured key alone no longer enables it (off by default).
- **Documented**: AI vars (`LLM_API_URL`, `OPENAI_API_KEY`, `ENABLE_OPENAI`) added to `.env.example` with a privacy note; `api.openai.com` added to the `docs/privacy.md` §7.3 egress table; the "no telemetry" line now names the opt-in exception.

## L8 — `.env.example` Redis URLs missing the password
`REDIS_URL` / `CELERY_BROKER_URL` / `CELERY_RESULT_BACKEND` were `redis://redis:6379/N`, but prod runs `redis-server --requirepass`, so a `cp .env.example .env` stack never went healthy (`NOAUTH`) — and a frustrated operator might drop `--requirepass`, re-opening the unauth-Redis hole closed in v2.5.6. URLs now embed the password placeholder, with a sync note.

## L13 — Art. 23 final-report deadline computed from the wrong event
The ACN CSIRT early-warning artifact set `final_report_deadline = detected + 30d`. NIS2 **Art. 23(4)(d)** requires the final report **1 month from the notification** (the 72h report), so the artifact told operators it was due ~a month too early — contradicting the "1 month from notification" label the incident model already uses. Now `detected + 72h + 30d`.

## Verification
- `ruff` + `py_compile` clean.
- `enable_openai` defaults **False**; `remediation` router imports; `/explain` still role-gated (from #143).
- Deadline math asserted (detection + 72h + 30d = +33d).
- `test_incident_deadline_alerts.py` **26/26** (deadline area unaffected).

## Noted, not done here
The README also carries a "no cloud" data-flow line; updating it to mention the opt-in OpenAI egress is a small follow-up (the authoritative GDPR disclosure is `privacy.md` §7.3, updated here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
