### PR TITLE
security: cap Playwright fan-out + container hardening (L5, L11)

### DIFF
--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -78,6 +78,8 @@ services:
       context: ../..
       dockerfile: packages/api/Dockerfile
     command: gunicorn app.main:app -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000
+    # L11: block setuid-based privilege escalation inside the container.
+    security_opt: ["no-new-privileges:true"]
     volumes:
       - reports-data:/tmp/nis2-reports
     env_file: ../../.env
@@ -101,6 +103,11 @@ services:
       context: ../..
       dockerfile: packages/api/Dockerfile
     command: celery -A app.tasks.celery_app worker --loglevel=info --concurrency=4
+    # L11: block privilege escalation + cap process fan-out. The worker spawns
+    # scan subprocesses and headless Chromium; pids_limit backstops a fork bomb
+    # without starving Chromium (gated to 2 concurrent by the scanner's L5 cap).
+    security_opt: ["no-new-privileges:true"]
+    pids_limit: 1024
     volumes:
       - reports-data:/tmp/nis2-reports
     env_file: ../../.env
@@ -142,6 +149,8 @@ services:
     # schedule to survive container restarts so cron-style triggers
     # don't double-fire after a deploy — hence the named volume.
     command: celery -A app.tasks.celery_app beat --loglevel=info --schedule=/var/celerybeat/schedule
+    # L11: block setuid-based privilege escalation inside the container.
+    security_opt: ["no-new-privileges:true"]
     volumes:
       - celerybeat_data:/var/celerybeat
     env_file: ../../.env

--- a/packages/scanner/nis2scan/legal.py
+++ b/packages/scanner/nis2scan/legal.py
@@ -5,6 +5,7 @@
 Regional and Legal Compliance Checks
 Validates security.txt, Italian P.IVA, Privacy Policy, Cookie Banners
 """
+import asyncio
 import ipaddress
 import re
 import logging
@@ -18,6 +19,11 @@ except ImportError:
     PLAYWRIGHT_AVAILABLE = False
 
 logger = logging.getLogger("nis2scan")
+
+# L5: cap concurrent headless-Chromium launches per scan. Each browser spawns
+# many processes; an unbounded fan-out (up to the scanner's `concurrency`,
+# default 20) can pin every scan slot in 30s renders and spike memory.
+_MAX_CONCURRENT_PLAYWRIGHT = 2
 
 # Internal/metadata hostnames Playwright must never be steered toward.
 _BLOCKED_HOSTNAMES = {
@@ -71,6 +77,11 @@ class LegalChecker:
             'cookie', 'accetta', 'accetto', 'consenso', 'accept cookies',
             'cookie policy', 'gestisci cookie', 'manage cookies'
         ]
+
+        # Gate concurrent Playwright launches (see _MAX_CONCURRENT_PLAYWRIGHT).
+        # Constructed here (no running loop needed in 3.10+); binds to the loop on
+        # first acquire — one LegalChecker per Scanner per Celery-task loop.
+        self._playwright_semaphore = asyncio.Semaphore(_MAX_CONCURRENT_PLAYWRIGHT)
 
     def check_security_txt(self, url: str, http_response: Optional[str]) -> Dict[str, Any]:
         """
@@ -165,6 +176,9 @@ class LegalChecker:
         logger.info(
             f"Starting Playwright dynamic check for {url} (pinned {host} -> {pinned_ip})"
         )
+        # L5: serialize browser launches through the per-checker semaphore;
+        # released in the finally below regardless of which path returns.
+        await self._playwright_semaphore.acquire()
         try:
             async with async_playwright() as p:
                 # We assume 'playwright install' has been run.
@@ -224,6 +238,8 @@ class LegalChecker:
         except Exception as e:
             logger.error(f"Playwright check failed: {e}")
             return {}
+        finally:
+            self._playwright_semaphore.release()
 
     async def analyze_page(
         self, url: str, html_body: str, pinned_ip: Optional[str] = None


### PR DESCRIPTION
Two defense-in-depth items from the security review.

## L5 — unbounded Playwright fan-out (scanner DoS-resilience)
The Playwright legal-check fallback launched **one headless Chromium per host with no cap**, so a batch of crafted targets could spin up to `concurrency` (default **20**) browsers — each a 30s `networkidle` render spawning many processes — pinning every scan slot and spiking memory. Gated launches through a per-`LegalChecker` `asyncio.Semaphore(2)`, acquired around the browser session and released in a `finally`. Per-instance (one checker per Scanner per Celery-task loop) so it binds to the right event loop.

## L11 — container hardening (app services)
- `security_opt: ["no-new-privileges:true"]` on **api / celery-worker / celery-beat** — blocks setuid-based privilege escalation, zero functional impact.
- `pids_limit: 1024` on the **worker** — backstops a fork bomb; generous enough for scan subprocesses + headless Chromium (now capped at 2 concurrent by L5).

### Deferred (need per-deployment tuning + live validation)
`mem_limit` (a wrong value OOM-kills the service), `cap_drop: ALL` (some images need caps at startup), `read_only` rootfs (needs explicit tmpfs per service), and extending these to the infra/web services.

## Verification
- `ruff` + `py_compile` clean.
- Prod compose parses; `no-new-privileges` asserted on the 3 app services, `pids_limit=1024` on the worker.
- Scanner suite **10/10** (legal `analyze_page` + core) — the semaphore doesn't break the static/dynamic path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
