### PR TITLE
security: bcrypt_sha256 to avoid bcrypt 72-byte truncation (L4)

### DIFF
--- a/packages/api/app/routers/auth.py
+++ b/packages/api/app/routers/auth.py
@@ -52,7 +52,12 @@ from app.utils.jwt import create_access_token, create_refresh_token, decode_toke
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+# bcrypt silently truncates at 72 bytes, so a >72-char passphrase only gets 72
+# bytes of entropy honoured. bcrypt_sha256 pre-hashes with SHA-256 (no length
+# limit) and is the default for new/updated hashes; plain bcrypt stays
+# registered so existing hashes still verify and are transparently upgraded on
+# next login (verify_and_update).
+pwd_context = CryptContext(schemes=["bcrypt_sha256", "bcrypt"], deprecated="auto")
 limiter = Limiter(key_func=get_remote_address)
 logger = logging.getLogger(__name__)
 
@@ -441,12 +446,19 @@ async def login(
             detail="Invalid email or password",
         )
 
-    if not pwd_context.verify(payload.password, user.password_hash):
+    password_ok, upgraded_hash = pwd_context.verify_and_update(
+        payload.password, user.password_hash
+    )
+    if not password_ok:
         await login_throttle.record_failure(payload.email)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid email or password",
         )
+    if upgraded_hash:
+        # Transparently migrate a legacy bcrypt hash to bcrypt_sha256 (persisted
+        # by the db.flush below). Only fires for deprecated/old-scheme hashes.
+        user.password_hash = upgraded_hash
 
     if not user.is_active:
         raise HTTPException(

--- a/packages/api/tests/test_password_hashing.py
+++ b/packages/api/tests/test_password_hashing.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""L4: passwords must not be silently truncated at bcrypt's 72-byte limit, and
+legacy bcrypt hashes must keep verifying + upgrade transparently. Pure passlib."""
+import passlib.hash
+
+from app.routers.auth import pwd_context
+
+
+def test_new_hashes_use_bcrypt_sha256():
+    h = pwd_context.hash("correct horse battery staple")
+    assert pwd_context.identify(h) == "bcrypt_sha256"
+
+
+def test_long_passphrase_not_truncated_at_72_bytes():
+    # Two passphrases identical for the first 72 bytes, differing only after.
+    base = "a" * 72
+    p1, p2 = base + "ONE", base + "TWO"
+    h1 = pwd_context.hash(p1)
+    assert pwd_context.verify(p1, h1)
+    # Under plain bcrypt this would WRONGLY be True (both truncate to `base`).
+    assert not pwd_context.verify(p2, h1)
+
+
+def test_legacy_bcrypt_hash_verifies_and_upgrades():
+    legacy = passlib.hash.bcrypt.hash("legacypw")
+    assert pwd_context.identify(legacy) == "bcrypt"
+
+    ok, new_hash = pwd_context.verify_and_update("legacypw", legacy)
+    assert ok
+    # bcrypt is deprecated → verify_and_update returns a fresh bcrypt_sha256 hash.
+    assert new_hash is not None
+    assert pwd_context.identify(new_hash) == "bcrypt_sha256"
+    assert pwd_context.verify("legacypw", new_hash)
+
+
+def test_wrong_password_does_not_upgrade():
+    legacy = passlib.hash.bcrypt.hash("legacypw")
+    ok, new_hash = pwd_context.verify_and_update("WRONG", legacy)
+    assert not ok
+    assert new_hash is None


### PR DESCRIPTION
Remediates **L4**.

## The bug
The password hasher was `CryptContext(schemes=["bcrypt"])`. Plain **bcrypt silently truncates at 72 bytes**, so a passphrase longer than 72 chars only gets 72 bytes of entropy honoured — extra characters add no protection. (Finding impact: strength/correctness gap; no realistic exploit, but inconsistent with the platform's claims.)

## The fix
- Default hash is now **bcrypt_sha256** (pre-hashes with SHA-256 → no length limit).
- Plain `bcrypt` stays registered (`deprecated="auto"`) so **existing hashes still verify**.
- Login uses `verify_and_update`, so a legacy bcrypt hash is **transparently re-hashed to bcrypt_sha256 on the next sign-in** and persisted by the existing flush.

**No user impact** — existing passwords keep working; the migration is automatic and silent.

## Verification
- `ruff` + `py_compile` clean.
- **29/29** tests: 4 new (`test_password_hashing.py` — new hashes are bcrypt_sha256; >72-byte passphrases are no longer truncation-equivalent; legacy bcrypt verifies + upgrades; wrong password doesn't upgrade) + `test_totp_mfa` + `test_jwt_rs256` regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)