### PR TITLE
security: encrypt sensitive JSONB columns at rest (L14)

### DIFF
--- a/packages/api/app/models/notification_channel.py
+++ b/packages/api/app/models/notification_channel.py
@@ -7,11 +7,12 @@ import uuid
 from typing import Optional
 
 from sqlalchemy import ARRAY, Boolean, ForeignKey, String, Text
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
 from app.models.base import TimestampMixin
+from app.utils.encrypted_types import EncryptedJSON
 
 
 class NotificationChannel(TimestampMixin, Base):
@@ -27,7 +28,9 @@ class NotificationChannel(TimestampMixin, Base):
         String(20), nullable=False
     )  # email, webhook, slack
     name: Mapped[str] = mapped_column(String(256), nullable=False)
-    config: Mapped[dict] = mapped_column(JSONB, default=dict, nullable=False)
+    # L14: notification credentials (Slack/webhook tokens, secrets) are
+    # sensitive at rest — encrypt the column.
+    config: Mapped[dict] = mapped_column(EncryptedJSON, default=dict, nullable=False)
     events: Mapped[Optional[list[str]]] = mapped_column(
         ARRAY(Text), default=list, nullable=True
     )

--- a/packages/api/app/models/scan_result.py
+++ b/packages/api/app/models/scan_result.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
 from app.models.base import TimestampMixin
+from app.utils.encrypted_types import EncryptedJSON
 
 if TYPE_CHECKING:
     from app.models.scan import Scan
@@ -48,8 +49,9 @@ class ScanResult(TimestampMixin, Base):
     whois_info: Mapped[Optional[dict]] = mapped_column(
         JSONB, default=dict, nullable=True
     )
+    # L14: leaked-secret evidence is sensitive at rest — encrypt the column.
     secrets_found: Mapped[Optional[dict]] = mapped_column(
-        JSONB, default=list, nullable=True
+        EncryptedJSON, default=list, nullable=True
     )
     errors: Mapped[Optional[list[str]]] = mapped_column(
         ARRAY(String), default=list, nullable=True

--- a/packages/api/app/utils/crypto.py
+++ b/packages/api/app/utils/crypto.py
@@ -3,6 +3,7 @@
 # NIS2 Compliance Platform — https://github.com/fabriziosalmi/nis2-public
 import base64
 import hashlib
+import json
 import os
 from typing import Optional
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
@@ -63,3 +64,27 @@ def decrypt_totp_secret(encrypted_str: Optional[str]) -> Optional[str]:
     except Exception:
         # Decryption failed; return as-is (legacy cleartext support)
         return encrypted_str
+
+
+def encrypt_json(value) -> str:
+    """AES-GCM-encrypt a JSON-serialisable value to a base64 string.
+
+    Keyed by the same DATA_ENCRYPTION_KEY as TOTP secrets
+    (get_totp_encryption_key). Used for field-level encryption of JSONB columns
+    that hold sensitive data at rest (leaked-secret evidence, notification
+    credentials). Format: base64(nonce[12] + ciphertext + tag[16]).
+    """
+    key = get_totp_encryption_key()
+    aesgcm = AESGCM(key)
+    nonce = os.urandom(12)
+    raw = json.dumps(value, separators=(",", ":")).encode("utf-8")
+    return base64.b64encode(nonce + aesgcm.encrypt(nonce, raw, None)).decode("utf-8")
+
+
+def decrypt_json(blob: str):
+    """Inverse of encrypt_json. Raises on tamper / wrong key (callers handle)."""
+    key = get_totp_encryption_key()
+    raw = base64.b64decode(blob.encode("utf-8"), validate=True)
+    nonce, ciphertext_tag = raw[:12], raw[12:]
+    aesgcm = AESGCM(key)
+    return json.loads(aesgcm.decrypt(nonce, ciphertext_tag, None).decode("utf-8"))

--- a/packages/api/app/utils/encrypted_types.py
+++ b/packages/api/app/utils/encrypted_types.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+# NIS2 Compliance Platform — https://github.com/fabriziosalmi/nis2-public
+"""SQLAlchemy column type that transparently encrypts JSON at rest (L14).
+
+The value is stored as a JSONB wrapper ``{"__enc__": "<base64 AES-GCM>"}``, so
+the column stays ``jsonb`` — no DDL migration is needed. Reads of legacy
+(pre-encryption) plaintext rows pass through unchanged, so existing data keeps
+working and is encrypted lazily as rows are rewritten. Keyed by
+DATA_ENCRYPTION_KEY (see app.utils.crypto / config).
+"""
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.types import TypeDecorator
+
+from app.utils.crypto import decrypt_json, encrypt_json
+
+logger = logging.getLogger(__name__)
+
+_WRAP_KEY = "__enc__"
+
+
+class EncryptedJSON(TypeDecorator):
+    """JSONB column whose value is AES-GCM-encrypted at rest."""
+
+    impl = JSONB
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        return {_WRAP_KEY: encrypt_json(value)}
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return None
+        # Encrypted wrapper → decrypt. Anything else is legacy plaintext.
+        if isinstance(value, dict) and set(value.keys()) == {_WRAP_KEY}:
+            try:
+                return decrypt_json(value[_WRAP_KEY])
+            except Exception:  # noqa: BLE001
+                # Wrong/rotated key or tampering — don't crash the read; surface
+                # the opaque wrapper and log. (A key rotation needs a re-encrypt
+                # migration; this keeps the API up meanwhile.)
+                logger.warning("EncryptedJSON: decryption failed; returning raw value")
+                return value
+        return value

--- a/packages/api/tests/test_encrypted_json.py
+++ b/packages/api/tests/test_encrypted_json.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""L14: field-level encryption of sensitive JSONB columns. Pure logic — the
+crypto round-trip + the EncryptedJSON TypeDecorator (no DB engine needed)."""
+from app.utils.crypto import decrypt_json, encrypt_json
+from app.utils.encrypted_types import EncryptedJSON
+
+
+def test_encrypt_json_round_trip():
+    for value in (
+        [{"type": "aws_key", "match": "AKIAIOSFODNN7EXAMPLE"}],
+        {"webhook_url": "https://hooks.slack.com/x", "secret": "s3cr3t-token"},
+        [],
+        {},
+    ):
+        blob = encrypt_json(value)
+        assert isinstance(blob, str)
+        # ciphertext must not leak the plaintext secrets
+        assert "AKIAIOSFODNN7EXAMPLE" not in blob
+        assert "s3cr3t-token" not in blob
+        assert decrypt_json(blob) == value
+
+
+def test_typedecorator_wraps_and_unwraps():
+    t = EncryptedJSON()
+    original = {"webhook_url": "https://hooks.slack.com/x", "secret": "abc123"}
+    stored = t.process_bind_param(original, None)
+    assert set(stored.keys()) == {"__enc__"}
+    assert "abc123" not in stored["__enc__"]
+    assert t.process_result_value(stored, None) == original
+
+
+def test_typedecorator_legacy_plaintext_passthrough():
+    t = EncryptedJSON()
+    # pre-encryption rows: a plain list or a dict without the wrapper key
+    assert t.process_result_value([{"type": "x"}], None) == [{"type": "x"}]
+    assert t.process_result_value({"url": "https://x"}, None) == {"url": "https://x"}
+
+
+def test_typedecorator_none_passthrough():
+    t = EncryptedJSON()
+    assert t.process_bind_param(None, None) is None
+    assert t.process_result_value(None, None) is None
+
+
+def test_typedecorator_decrypt_failure_returns_raw():
+    t = EncryptedJSON()
+    bad = {"__enc__": "not-valid-base64-or-ciphertext!!!"}
+    # Wrong/rotated key or tampering must not crash the read.
+    assert t.process_result_value(bad, None) == bad


### PR DESCRIPTION
Remediates **L14** (defense-in-depth at-rest encryption).

## The gap
Two JSONB columns held sensitive data in **plaintext at rest**:
- `scan_results.secrets_found` — leaked-secret *evidence* (AWS keys, tokens, etc. the scanner found).
- `notification_channels.config` — Slack/webhook **credentials** (tokens, signing secrets).

A DB dump, backup, disk image, or any read-capable role exposed them directly. RLS still scopes per-org reads, but at-rest confidentiality was missing.

## The fix
A new `EncryptedJSON` SQLAlchemy `TypeDecorator` that AES-GCM-encrypts the value (keyed by **`DATA_ENCRYPTION_KEY`** — the dedicated key added in M1) and stores it as a JSONB wrapper `{"__enc__": "<base64>"}`. Applied to both columns.

- **No DDL migration** — the column stays `jsonb` (the wrapper is itself valid JSON).
- **No data migration** — legacy plaintext rows are detected (no `__enc__` wrapper) and pass through unchanged; they encrypt lazily as rows are rewritten.
- **Fails safe on read** — a wrong/rotated key returns the opaque wrapper + logs, rather than crashing the read.

## Verification
- `ruff` + `py_compile` clean.
- **12/12** tests: 5 new (`test_encrypted_json.py` — crypto round-trip, wrap/unwrap, legacy-plaintext passthrough, None, decrypt-failure-returns-raw) + `test_data_encryption_key` (shared key).
- Model wiring asserted: both `secrets_found` and `config` resolve to `EncryptedJSON`; no circular import.

### Not exercised here (needs the integration suite / live Postgres)
The full ORM round-trip (insert → ciphertext in PG → select → decrypted) — the integration tests require a real Postgres. The TypeDecorator's bind/result logic and the crypto are unit-tested above; the column type is a transparent swap over the existing `jsonb`.

## Note
Rotating `DATA_ENCRYPTION_KEY` would require a one-off re-encrypt migration (existing rows become unreadable, same as M1's TOTP secrets). Documented in the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
