### PR TITLE
security: validate finding assignee membership + fix Dockerfile pin comment (I4, I6)

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -1,6 +1,6 @@
-# Pinned to the immutable manifest digest of python:3.12.7-slim-bookworm.
-# Refresh with: docker pull python:3.12.7-slim-bookworm && \
-#               docker inspect --format='{{index .RepoDigests 0}}' python:3.12.7-slim-bookworm
+# Pinned to the immutable manifest digest of python:3.14.5-slim-bookworm.
+# Refresh with: docker pull python:3.14.5-slim-bookworm && \
+#               docker inspect --format='{{index .RepoDigests 0}}' python:3.14.5-slim-bookworm
 FROM python:3.14.5-slim-bookworm@sha256:a3974109d36f164ca70024bc0d0828ac706e4ccda849f8638d879e91f79e90ec
 
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/packages/api/app/routers/findings.py
+++ b/packages/api/app/routers/findings.py
@@ -155,6 +155,24 @@ async def update_finding(
         )
 
     update_data = payload.model_dump(exclude_unset=True)
+
+    # I4: an assignee must be a member of THIS org. Otherwise an admin/auditor
+    # could write an arbitrary (foreign) user UUID into assigned_to — leaking
+    # that id and corrupting assignment-based UI / notifications.
+    assignee = update_data.get("assigned_to")
+    if assignee is not None:
+        member = await db.execute(
+            select(Membership.id).where(
+                Membership.user_id == assignee,
+                Membership.organization_id == membership.organization_id,
+            )
+        )
+        if member.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="assigned_to must be a member of this organization",
+            )
+
     for field, value in update_data.items():
         setattr(finding, field, value)
 


### PR DESCRIPTION
Two small Info items.

## I4 — IDOR-lite on finding assignment
`PATCH /findings/{id}` blind-`setattr`'d the request payload, so an admin/auditor could write **any (foreign) user UUID** into `assigned_to`. RLS still blocked cross-tenant *reads*, but this leaked a foreign user id and corrupted assignment-based UI / notifications. Now the assignee must have a `Membership` in the finding's organization, else **400**. (A random/non-existent UUID already failed the FK; this closes the *valid-but-foreign* case.)

## I6 — Dockerfile pin comment mismatch
The comment said `python:3.12.7` while `FROM` pins `3.14.5-slim-bookworm@sha256:…`, and the documented refresh command re-pinned the wrong line. No exploit (the digest pin makes the build deterministic) — a maintenance/provenance hazard. Comment + refresh command now match the real pinned tag.

## Verification
- `ruff` + `py_compile` clean; `findings` router imports, `PATCH /{finding_id}` present.
- I6 confirmed: the comment and `FROM` now both read 3.14.5.
- Not exercised: the membership-check 400 path (needs the integration suite / a live DB with two orgs). The change is a localized guard before the existing setattr loop.

## Coming next
**I3** (the matrix marks business-continuity 'Partially Automated' from an MX-record count) also lives in `compliance.py` — it'll go in once #149 (I1/I2, same file) is merged, to keep that file's history clean.