### PR TITLE
fix(report): render executive summary instead of showing raw HTML (+ escape data at source)

### DIFF
--- a/packages/api/app/tasks/report_tasks.py
+++ b/packages/api/app/tasks/report_tasks.py
@@ -466,7 +466,12 @@ def _gen_markdown(scan, results, findings, base, locale: str = "en") -> dict:
         lines.append(f"## {_t(locale, 'executive_summary')}\n")
         # Blockquote — escape pipes/asterisks/etc inside the body
         # so a `*emphasis*` from the user doesn't reflow the doc.
-        lines.append(f"> {_md(scan.executive_summary)}\n")
+        # executive_summary is HTML; strip tags to readable plain text for the
+        # Markdown report (Markdown viewers don't reliably render embedded HTML,
+        # and escaping it showed the raw tags). The inner text is still _md-escaped.
+        _summary_text = html.unescape(re.sub(r"<[^>]+>", " ", scan.executive_summary))
+        _summary_text = re.sub(r"\s+", " ", _summary_text).strip()
+        lines.append(f"> {_md(_summary_text)}\n")
 
     # Findings table
     lines.append(f"## {_t(locale, 'findings')}\n")
@@ -646,16 +651,19 @@ def _gen_html(scan, results, findings, base, locale: str = "en") -> dict:
             f"<td>{_h(ports)}</td></tr>\n"
         )
 
-    # Executive summary — escape the user-supplied text inside an
-    # otherwise-static `<div class="executive">`. Pre-v2.4.19 this
-    # was string-concat'd raw, opening an XSS that fired the moment
-    # someone opened the report (or its PDF rendering pulled the
-    # injected JS into the print pipeline).
+    # Executive summary — RENDERED, not escaped. The scanner's SummaryGenerator
+    # emits HTML (<div>/<strong>/<a>/<ul>…); html.escape()'ing it here showed the
+    # raw tags verbatim instead of the formatted summary. It is safe to render
+    # because SummaryGenerator now html-escapes every DATA value it interpolates
+    # (risk names, finding text, references) at the source, so the only HTML left
+    # is its own static structural tags. (Pre-v2.4.19 this was raw AND the data
+    # was unescaped — THAT was the XSS; escaping the data at the source closes it,
+    # without flattening the formatting.)
     exec_block = ""
     if scan.executive_summary:
         exec_block = (
             f"<h2>{_h(_t(locale, 'executive_summary'))}</h2>"
-            f'<div class="executive">{_h(scan.executive_summary)}</div>'
+            f'<div class="executive">{scan.executive_summary}</div>'
         )
 
     # The lang attribute matches the user's requested locale (audit

--- a/packages/scanner/nis2scan/summary.py
+++ b/packages/scanner/nis2scan/summary.py
@@ -1,8 +1,21 @@
 # Copyright (c) 2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 # NIS2 Compliance Platform — https://github.com/fabriziosalmi/nis2-public
+import html
 from typing import List, Dict, Any
 from dataclasses import dataclass
+
+
+def _esc(value) -> str:
+    """HTML-escape a value embedded into the executive-summary markup.
+
+    The summary is *rendered* (not escaped) by the report generators and the
+    web UI, so every DATA interpolation MUST be escaped here at the source —
+    otherwise a finding/risk string containing `<script>` injects into the
+    report HTML. The structural tags below are static and stay raw.
+    """
+    return html.escape(str(value))
+
 
 @dataclass
 class BusinessRisk:
@@ -183,7 +196,7 @@ class SummaryGenerator:
             # Link to GDPR
             url = "https://eur-lex.europa.eu/eli/reg/2016/679/oj"
 
-        return f'<a href="{url}" target="_blank" title="Approfondisci: {reference}" style="text-decoration: none; font-size: 0.9em; margin-left: 4px; vertical-align: middle;">📖</a>'
+        return f'<a href="{url}" target="_blank" title="Approfondisci: {_esc(reference)}" style="text-decoration: none; font-size: 0.9em; margin-left: 4px; vertical-align: middle;">📖</a>'
 
     def _build_html(self, report, risks: List[BusinessRisk], metrics: Dict[str, Any], action_plan: List[Dict[str, str]]) -> str:
         """Construct the final HTML string."""
@@ -192,7 +205,7 @@ class SummaryGenerator:
         html = f"""
         <div style="margin-bottom: 20px;">
             <p class="executive-text">
-                <strong>Audit Status:</strong> <span style="color: {'#ef4444' if metrics['status'] == 'CRITICAL' else '#eab308' if metrics['status'] == 'IMPROVEMENT NEEDED' else '#10b981'}">{metrics['status']}</span>
+                <strong>Audit Status:</strong> <span style="color: {'#ef4444' if metrics['status'] == 'CRITICAL' else '#eab308' if metrics['status'] == 'IMPROVEMENT NEEDED' else '#10b981'}">{_esc(metrics['status'])}</span>
                 (Score: {metrics['score']}/100)
             </p>
             <p class="executive-text">
@@ -215,7 +228,7 @@ class SummaryGenerator:
 
                 html += f"""
                 <li style="margin-bottom: 8px;">
-                    <strong>{risk.name}:</strong> {risk.impact} {ref_link}
+                    <strong>{_esc(risk.name)}:</strong> {_esc(risk.impact)} {ref_link}
                 </li>
                 """
             html += "</ul></div>"
@@ -229,9 +242,9 @@ class SummaryGenerator:
 
                 html += f"""
                 <li style="margin-bottom: 8px;">
-                    <strong style="color: {priority_color};">{action['priority']}:</strong> {action['step']} {ref_link}
+                    <strong style="color: {priority_color};">{_esc(action['priority'])}:</strong> {_esc(action['step'])} {ref_link}
                     <div style="font-size: 0.85em; color: var(--text-muted); margin-top: 2px;">
-                        Issue: {action['finding']} | Affects: {action['target']}
+                        Issue: {_esc(action['finding'])} | Affects: {_esc(action['target'])}
                     </div>
                 </li>
                 """

--- a/packages/scanner/tests/test_summary_escaping.py
+++ b/packages/scanner/tests/test_summary_escaping.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""The executive summary is rendered (not escaped) by the reports + UI, so the
+SummaryGenerator MUST html-escape every DATA value it interpolates — otherwise a
+finding/risk string with <script> injects into the report. The structural tags
+stay raw so the summary still renders."""
+from nis2scan.summary import BusinessRisk, SummaryGenerator, _esc
+
+
+def test_esc_escapes_markup():
+    assert _esc("<script>alert(1)</script>") == "&lt;script&gt;alert(1)&lt;/script&gt;"
+    assert _esc('"><img src=x>') == "&quot;&gt;&lt;img src=x&gt;"
+
+
+class _Report:
+    stats = {"analyzed_hosts": 1}
+
+
+def test_build_html_escapes_injected_data_but_keeps_structure():
+    gen = SummaryGenerator()
+    metrics = {
+        "status": "<script>x</script>",
+        "score": 50,
+        "total_findings": 1,
+        "critical_count": 1,
+        "high_count": 0,
+    }
+    risks = [
+        BusinessRisk(
+            name="<img src=x onerror=alert(1)>",
+            impact="<b>boom</b>",
+            probability="High",
+            related_findings=[],
+        )
+    ]
+    action_plan = [
+        {
+            "priority": "Immediate",
+            "step": "<script>s</script>",
+            "finding": "<i>f</i>",
+            "target": "evil<svg>",
+            "reference": 'NIS2"><script>',
+        }
+    ]
+
+    out = gen._build_html(_Report(), risks, metrics, action_plan)
+
+    # No LIVE injected tags survive...
+    assert "<script>" not in out
+    assert "<img" not in out
+    assert "onerror=alert(1)>" not in out  # the live attribute form is gone
+    # ...the data is present but escaped...
+    assert "&lt;script&gt;" in out
+    assert "&lt;img" in out
+    # ...and the generator's own structural tags ARE rendered (not escaped).
+    assert "<ul" in out and "<li" in out and "<strong>" in out


### PR DESCRIPTION
Fixes the reported bug: **report generation emits HTML that's shown verbatim instead of rendered**.

## Diagnosis
`scan.executive_summary` is **HTML** produced by the scanner's `SummaryGenerator` (`<div>/<strong>/<a>/<ul>…`). Three consumers handled it three ways:

| Output | Before | Result |
|---|---|---|
| Web UI | `SafeHtml` allowlist sanitizer → renders | ✅ |
| Report **HTML/PDF** | `html.escape()` | ❌ raw tags shown **verbatim** |
| Report **Markdown** | `_md()` escape | ❌ verbatim |

And the deeper problem: `SummaryGenerator` interpolated finding/risk **data raw** into the HTML (`risk.name`, `risk.impact`, `reference`…), so the summary was **unsafe-by-construction** — which is *why* the reports defensively escaped everything (and the UI needed a sanitizer). The pre-v2.4.19 XSS was raw-insertion **of unescaped data**; escaping the whole block fixed the XSS but broke rendering.

## Fix (escape at the source, render downstream)
1. **Scanner** (`summary.py`): `html.escape()` every DATA value the summary interpolates; the structural tags are static → the summary is now **safe-by-construction**.
2. **Report HTML/PDF** (`_gen_html`, reused by `_gen_pdf` via WeasyPrint): insert `executive_summary` **raw** so it renders.
3. **Report Markdown**: strip tags to readable plain text (Markdown viewers don't reliably render embedded HTML).
4. The UI's `SafeHtml` stays as defense-in-depth.

This also **closes the latent XSS** that the UI sanitizer was masking.

## Verification
- `ruff` + `py_compile` clean.
- New `test_summary_escaping.py`: an injected `<script>` / `<img onerror>` is escaped (`&lt;script&gt;`, no live tag) while the generator's own `<ul>/<li>/<strong>` still render. **15/15** scanner tests.
- Confirmed `_gen_pdf` reuses `_gen_html`, so PDF is covered.
- Not exercised here: the actual WeasyPrint PDF render + opening the HTML report in a browser (needs the report pipeline / a live run).

## Note
A general **UI sweep** (other `dangerouslySetInnerHTML`, error/empty states, a11y) was requested separately and is parked for a follow-up.