### PR TITLE
chore(release): bump version to 2.5.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nis2-public-docs",
-  "version": "2.5.13",
+  "version": "2.5.14",
   "private": true,
   "description": "VitePress documentation build for the NIS2 Continuous Posture Management Platform.",
   "scripts": {

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nis2-api"
-version = "2.5.13"
+version = "2.5.14"
 description = "NIS2 Compliance Platform API"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/scanner/pyproject.toml
+++ b/packages/scanner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nis2scan"
-version = "2.5.13"
+version = "2.5.14"
 description = "NIS2 Directive compliance scanner engine"
 requires-python = ">=3.10"
 dependencies = [

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nis2/web",
-  "version": "2.5.13",
+  "version": "2.5.14",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Patch release capturing the security-remediation work merged since 2.5.13.

Bumps all four package versions (root `package.json`, `packages/web`, `packages/api`, `packages/scanner`) → **2.5.14**.

## What landed in this release
- **High:** H1–H4 (cert/scanner SSRF, schedule authz, prod Celery), H5 worker boot-guard
- **Medium:** M1 (TOTP key), M2→#140, M3 (login lockout), M4/M5 (dev bind + LLM rate-limit), M6 (body cap), M7 (TOCTOU 409)
- **Low:** L4 (bcrypt_sha256), L5 (Playwright cap), L7/L8 (OpenAI disclosure + Redis env), L11 (container hardening), L13 (Art.23 deadline), L14 (field encryption)
- **Info:** I1/I2 (NIS2 letter mapping), I4 (finding-assignee membership), I6 (Dockerfile pin)
- **Fix:** report executive-summary HTML rendering (+ data escaped at source)

Remaining RLS least-privilege epic: #140. UI sweep: follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)