### PR TITLE
cleanup: drop MX→BC matrix inference + hard-fail on missing prod passwords (I3, L10)

### DIFF
--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -32,7 +32,7 @@ services:
     image: postgres:16-alpine
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-nis2}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in .env}
       POSTGRES_DB: ${POSTGRES_DB:-nis2}
     volumes: [pgdata:/var/lib/postgresql/data]
     healthcheck:
@@ -44,13 +44,13 @@ services:
 
   redis:
     image: redis:7-alpine
-    # `${VAR:-default}` (docker compose syntax): falls back to "changeme"
-    # if .env is missing the key (e.g. user copied .env.example but forgot
-    # to fill it). Without the default, an empty string is passed to
-    # redis-server which then refuses to start with "ERR wrong number of
-    # arguments for 'requirepass'", and the healthcheck never goes green.
-    # Reported by Davide on `make prod` from Windows / WSL2.
-    command: redis-server --requirepass ${REDIS_PASSWORD:-changeme}
+    # `${VAR:?msg}` (docker compose syntax): HARD-FAIL with a clear message if
+    # REDIS_PASSWORD is unset/empty, instead of silently falling back to the
+    # well-known "changeme". A weak default on the broker — even on an
+    # internal-only port — is worse than a loud startup error pointing the
+    # operator at .env. (The `:?` form also avoids the empty-string
+    # "ERR wrong number of arguments for 'requirepass'" crash Davide hit.)
+    command: redis-server --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD must be set in .env}
     environment:
       # Re-expose the password inside the container so the healthcheck
       # below can read it from $REDIS_PASSWORD instead of having compose
@@ -58,7 +58,7 @@ services:
       #   (a) the same compose file works whether `.env` has the var or not;
       #   (b) the password isn't baked into the rendered spec (visible via
       #       `docker inspect`), only into the container's env.
-      REDIS_PASSWORD: ${REDIS_PASSWORD:-changeme}
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD must be set in .env}
     healthcheck:
       # `$$` escapes one $ so docker compose passes literal `$REDIS_PASSWORD`
       # to the shell inside the container, which then expands it. The

--- a/packages/scanner/nis2scan/compliance.py
+++ b/packages/scanner/nis2scan/compliance.py
@@ -108,7 +108,6 @@ class ComplianceEngine:
         # Track positive indicators for matrix automation
         has_security_txt = False
         has_spf_dmarc = False
-        has_redundancy = False
 
         for host in scan_results:
             stats['analyzed_hosts'] += 1
@@ -126,10 +125,6 @@ class ComplianceEngine:
             # 2. SPF/DMARC (Secure Communications)
             if host.dns_info.get('spf', {}).get('present') or host.dns_info.get('dmarc', {}).get('present'):
                 has_spf_dmarc = True
-
-            # 3. Redundancy (MX Records)
-            if len(host.dns_info.get('mx', [])) > 1:
-                has_redundancy = True
 
             stats['active_hosts'] += 1
             host_findings = []
@@ -792,8 +787,9 @@ class ComplianceEngine:
         if has_spf_dmarc:
             nis2_matrix["j) MFA & Communications"] = "Partially Automated (Email Security Verified)"
 
-        if has_redundancy:
-             nis2_matrix["c) Business Continuity & Crisis Mgmt"] = "Partially Automated (Redundancy Detected)"
+        # I3: an MX-record count is NOT evidence of business continuity / backup
+        # / DR / crisis management, so Art. 21.2.c stays "Manual Verification
+        # Required" rather than being inferred from DNS redundancy.
 
         # Enhanced Automation Status
         nis2_matrix["g) Cyber Hygiene & Training"] = "Partially Automated (Info Leakage & Header Checks)"


### PR DESCRIPTION
Two quick items from the review's tail.

## I3 — MX-record → business-continuity matrix inference
The compliance matrix marked **Art. 21.2.c "Partially Automated (Redundancy Detected)"** whenever a host had >1 MX record. MX count is not evidence of business continuity / backup / DR / crisis management — it overstated coverage. Removed the inference (+ the now-unused `has_redundancy` tracking); **21.2.c stays "Manual Verification Required"**.

## L10 — weak default password on prod Redis/Postgres
Prod Redis ran `--requirepass ${REDIS_PASSWORD:-changeme}`, so a missing `REDIS_PASSWORD` silently fell back to a well-known value. The port is internal-only (no host publish), but a weak broker default is poor hygiene. Switched to **`${REDIS_PASSWORD:?…}`** (hard-fail with a clear message) and applied the same to **`POSTGRES_PASSWORD`**. The `:?` form also prevents the empty-string `requirepass` crash the old default guarded against.

## Verification
- `ruff` + `py_compile` clean; **0** `has_redundancy` refs left; **13/13** scanner tests (compliance-letter test still green).
- Prod compose parses; the three `:?` substitutions present.

## Verdicts on the other two 'needs-confirmation' items (investigated, not in this PR)
- **L9** (unpinned deps): **confirmed gap** — no lockfile is applied at build (`pip install` resolves pyproject `>=` ranges). Proper fix = a hash-pinned lockfile + CI `pip-audit` against it (a build-process change, best validated in CI) — recommend as a follow-up.
- **L12** (`script-src 'unsafe-inline'`): **not currently exploitable** (executive_summary is now escaped-at-source + SafeHtml; other content is React-escaped). Proper fix = nonce-based CSP via a Next.js middleware → folding into the UI sweep.