### PR TITLE
feat(web): App Router error + not-found boundaries (UI sweep)

### DIFF
--- a/packages/web/src/app/error.tsx
+++ b/packages/web/src/app/error.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+// NIS2 Compliance Platform — https://github.com/fabriziosalmi/nis2-public
+"use client"
+
+import { useEffect } from "react"
+
+/**
+ * App Router error boundary. Catches render/runtime errors in any route segment
+ * and shows a branded fallback with a retry, instead of Next.js's raw default
+ * error screen. Intentionally dependency-light (plain elements + Tailwind, no
+ * i18n) so it still renders even if the failure is in shared providers.
+ */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    // Surface to the browser console / error tracker; the digest correlates
+    // with the server log for the same error.
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center">
+      <h2 className="text-2xl font-semibold">Something went wrong</h2>
+      <p className="max-w-md text-sm text-muted-foreground">
+        An unexpected error occurred. You can try again — if the problem
+        persists, contact your administrator.
+      </p>
+      {error.digest ? (
+        <p className="font-mono text-xs text-muted-foreground/70">
+          Ref: {error.digest}
+        </p>
+      ) : null}
+      <button
+        onClick={reset}
+        className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+      >
+        Try again
+      </button>
+    </div>
+  )
+}

--- a/packages/web/src/app/not-found.tsx
+++ b/packages/web/src/app/not-found.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-only
+// NIS2 Compliance Platform — https://github.com/fabriziosalmi/nis2-public
+import Link from "next/link"
+
+/**
+ * App Router 404 page. Replaces Next.js's raw default for unknown URLs (or any
+ * `notFound()` call) with a branded fallback. Dependency-light on purpose.
+ */
+export default function NotFound() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center">
+      <h2 className="text-2xl font-semibold">Page not found</h2>
+      <p className="max-w-md text-sm text-muted-foreground">
+        The page you&apos;re looking for doesn&apos;t exist or has moved.
+      </p>
+      <Link
+        href="/dashboard"
+        className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+      >
+        Back to dashboard
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
From the UI sweep (the frontend is otherwise in good shape — only `SafeHtml` uses `dangerouslySetInnerHTML`, images have alt, empty/loading/label/aria coverage is solid).

**Gap:** no App Router error boundaries — a render/runtime error in any route, or an unknown URL, fell through to Next.js's raw default screen.

- `app/error.tsx` — branded error boundary with a **Try again** (reset) + the error digest for log correlation.
- `app/not-found.tsx` — branded 404 with a link back to the dashboard.

Both are **dependency-light** (plain elements + the app's Tailwind tokens, no i18n) on purpose, so they still render even if a shared provider is what failed.

## Verification
- `tsc --noEmit` clean on both files; CI **Web Build** + **Lint** validate compilation.
- Not runtime-exercised here (would need the full app + an induced error/404) — the files use the standard Next.js `error.tsx`/`not-found.tsx` signatures.

## UI sweep — the rest (recommendations, not in this PR)
- **L6** (client-side-only route guard): recommend **leave** — a server middleware is UX-risky here (the `refresh_token` cookie is path-scoped to `/api/v1/auth`, invisible at `/dashboard`, so a naive token check would bounce users with a refreshable session). API enforces real authz.
- **L12** (`script-src 'unsafe-inline'`): not exploitable post-#151; nonce-CSP is a deliberate task needing runtime testing.
- `err.message` raw in toast descriptions: low priority.