### PR TITLE
feat(api): per-task RLS org context + app-role SQL (H5, part 1)

### DIFF
--- a/docs/h5-rls-validation.md
+++ b/docs/h5-rls-validation.md
@@ -1,0 +1,90 @@
+# H5 — validating RLS under a least-privilege DB role
+
+The platform's tenant isolation is Postgres Row-Level Security. RLS is **bypassed**
+for `SUPERUSER` / `BYPASSRLS` roles, so while the app connects as the bootstrap
+superuser (`nis2`) the policies are decorative — isolation rests on the app-layer
+`organization_id` filters alone. This runbook switches the app + worker to a
+`NOSUPERUSER NOBYPASSRLS` role so the policies actually apply, and validates it.
+
+> **Status of the H5 stack when you run this**
+> - **Done & safe to validate now:** manual scans (PR #155) and report generation
+>   (PR #158) set the worker's RLS org context before their tenant reads.
+> - **WIP — expect breakage until the later chunks land** (tracked on #140):
+>   *scheduled* scans (the beat sweep isn't org-looped yet) and *API-key* auth
+>   (the `api_keys` lookup isn't RLS-exempt yet). Validate the **manual scan +
+>   report** path first; don't cut scheduled/API-key traffic over until those land.
+
+## 1. Provision the role
+
+Fresh deploy: drop [`infra/docker/initdb/01-create-app-role.sql`](../infra/docker/initdb/01-create-app-role.sql)
+into the postgres container's `/docker-entrypoint-initdb.d/` (runs once on first
+volume init).
+
+Existing deploy (volume already initialised): run it once as the superuser —
+
+```bash
+psql "$SUPERUSER_DATABASE_URL" -v app_pw="$NIS2_APP_PASSWORD" \
+     -f infra/docker/initdb/01-create-app-role.sql
+```
+
+Confirm the role is least-privilege:
+
+```sql
+SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = 'nis2_app';
+-- expect: f | f
+```
+
+## 2. Point the app + worker at the role (keep the superuser for migrations)
+
+DDL (migrations) still needs the superuser — `nis2_app` has DML only. Keep two URLs:
+
+```bash
+# .env
+SUPERUSER_DATABASE_URL=postgresql+asyncpg://nis2:<su_pw>@db:5432/nis2      # migrations only
+DATABASE_URL=postgresql+asyncpg://nis2_app:<app_pw>@db:5432/nis2          # api + worker
+```
+
+Run migrations as the superuser, then start the app on the app role:
+
+```bash
+DATABASE_URL="$SUPERUSER_DATABASE_URL" alembic upgrade head
+docker compose -f infra/docker/docker-compose.prod.yml up -d   # api/worker/beat read DATABASE_URL
+```
+
+The worker boot guard (`assert_db_role_rls_safe`) and the API lifespan should now
+start **without** the "rolsuper/rolbypassrls — RLS bypassed" warning. If you see
+`Refusing to start: ... SUPERUSER/BYPASSRLS app role`, the app is still on the
+superuser URL.
+
+## 3. Acceptance test
+
+The point is to prove isolation holds **even with the app-layer filters removed** —
+i.e. the database itself refuses cross-tenant reads.
+
+1. **Manual scan persists (part 1).** Trigger a scan in org A from the UI/API. It
+   must reach `completed` with findings. If findings come back empty / the scan
+   stalls in `running`, `set_rls_org_context` isn't taking effect — check the
+   worker connects as `nis2_app` and `CELERY_WORKER=1` is set (NullPool).
+2. **Report generates (part 2).** Download a report for that scan → non-empty.
+3. **Cross-tenant read is refused at the DB.** As `nis2_app` in psql, simulate org
+   A's context and confirm org B's rows are invisible:
+
+   ```sql
+   SELECT set_config('app.current_org_id', '<ORG_A_UUID>', false);
+   SELECT count(*) FROM scans;                          -- only org A's scans
+   SELECT count(*) FROM scans WHERE organization_id = '<ORG_B_UUID>';  -- expect 0
+   ```
+
+   0 rows for org B is the proof RLS is doing the work, not just the API.
+
+## 4. Rollback
+
+Point `DATABASE_URL` back at the superuser URL and restart. Nothing in the schema
+changed, so this is instant and lossless.
+
+## What to report back
+
+Per the acceptance test: do manual scans + reports work under `nis2_app`, and does
+psql confirm 0 cross-tenant rows? Anything that breaks (especially scheduled scans
+or API-key auth) is expected until the remaining #140 chunks land — note which, so
+the per-org sweep / `api_keys` exemption can be prioritised.

--- a/infra/docker/initdb/01-create-app-role.sql
+++ b/infra/docker/initdb/01-create-app-role.sql
@@ -25,17 +25,16 @@
 
 \set ON_ERROR_STOP on
 
--- 1. The role (idempotent).
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nis2_app') THEN
-    EXECUTE format(
-      'CREATE ROLE nis2_app LOGIN NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE PASSWORD %L',
-      :'app_pw'
-    );
-  END IF;
-END
-$$;
+-- 1. The role (idempotent). psql does NOT interpolate :'app_pw' inside a
+--    dollar-quoted DO block, so build the CREATE statement in plain SQL (where
+--    psql DOES substitute the variable) and run it with \gexec. WHERE NOT EXISTS
+--    makes it a no-op when the role already exists.
+SELECT format(
+  'CREATE ROLE nis2_app LOGIN NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE PASSWORD %L',
+  :'app_pw'
+)
+WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nis2_app')
+\gexec
 
 -- 2. DML (no DDL) on the current schema + everything migrations create later.
 GRANT USAGE ON SCHEMA public TO nis2_app;

--- a/infra/docker/initdb/01-create-app-role.sql
+++ b/infra/docker/initdb/01-create-app-role.sql
@@ -1,0 +1,54 @@
+-- ============================================================================
+-- H5: least-privilege application DB role.
+-- ============================================================================
+-- The platform's tenant isolation is Postgres Row-Level Security. RLS policies
+-- are BYPASSED for SUPERUSER / BYPASSRLS roles, so if the API + worker connect
+-- as the bootstrap superuser (the default `nis2` in the postgres image) the
+-- policies are decorative — isolation rests on app-layer org_id filters only.
+--
+-- This script provisions a NOSUPERUSER NOBYPASSRLS role the policies actually
+-- apply to. Point the API + worker DATABASE_URL at it; keep the bootstrap
+-- superuser for migrations only.
+--
+-- HOW TO APPLY
+--   Fresh deploy: drop this file in the postgres container's
+--     /docker-entrypoint-initdb.d/ (runs once, on first volume init).
+--   Existing deploy (volume already initialised): run it once manually as the
+--     superuser, e.g.
+--       psql "$SUPERUSER_DATABASE_URL" -v app_pw="$NIS2_APP_PASSWORD" \
+--            -f 01-create-app-role.sql
+--
+-- Requires the psql variable `app_pw` (the new role's password). With the
+-- docker-entrypoint-initdb.d path, set it via a tiny wrapper that exports it as
+-- a psql var, or replace :'app_pw' with the value at deploy time.
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+-- 1. The role (idempotent).
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'nis2_app') THEN
+    EXECUTE format(
+      'CREATE ROLE nis2_app LOGIN NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE PASSWORD %L',
+      :'app_pw'
+    );
+  END IF;
+END
+$$;
+
+-- 2. DML (no DDL) on the current schema + everything migrations create later.
+GRANT USAGE ON SCHEMA public TO nis2_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO nis2_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO nis2_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO nis2_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO nis2_app;
+
+-- 3. (M2 — append-only audit log) Enable ONCE the audit-log retention purge in
+--    cleanup_tasks runs under a separate maintenance role (or a SECURITY DEFINER
+--    function); otherwise the purge silently deletes 0 rows. Until then, leave
+--    commented so the existing cleanup keeps working.
+--
+--   REVOKE UPDATE, DELETE ON audit_logs FROM nis2_app;

--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -113,6 +113,39 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
             await session.close()
 
 
+async def set_rls_org_context(session: AsyncSession, org_id, user_id=None) -> None:
+    """Set the RLS org context on a Celery/background-task session (H5).
+
+    The API does this in get_db from IdentityMiddleware ContextVars; the worker
+    has no request context, so each task must set `app.current_org_id` explicitly
+    with the org id of the entity it operates on. Without it, every tenant-scoped
+    query returns 0 rows under a NOSUPERUSER NOBYPASSRLS role (and the audit-log
+    retention DELETE removes 0 rows).
+
+    Unlike get_db this uses `is_local => false` (session/connection-scoped, NOT
+    transaction-scoped): a task issues several commits (scan -> running, then
+    persist findings), and a transaction-scoped SET LOCAL would be cleared by the
+    first commit, dropping context for the rest. Session scope is safe here ONLY
+    because the worker runs with NullPool (CELERY_WORKER=1) — a fresh asyncpg
+    connection per task, closed on release, so nothing leaks to another tenant's
+    task. Do NOT call this on a pooled (API) connection.
+
+    No-op on non-Postgres or when org_id is None (keeps the superuser/legacy path
+    working unchanged).
+    """
+    if not IS_POSTGRES or org_id is None:
+        return
+    await session.execute(
+        text("SELECT set_config('app.current_org_id', :v, false)"),
+        {"v": str(org_id)},
+    )
+    if user_id is not None:
+        await session.execute(
+            text("SELECT set_config('app.current_user_id', :v, false)"),
+            {"v": str(user_id)},
+        )
+
+
 async def ensure_schema() -> None:
     """Best-effort idempotent schema bootstrap (dev / first-run convenience).
 

--- a/packages/api/app/routers/scans.py
+++ b/packages/api/app/routers/scans.py
@@ -146,7 +146,7 @@ async def create_scan(
     try:
         from app.tasks.scan_tasks import run_scan_task
 
-        task = run_scan_task.delay(str(scan.id))
+        task = run_scan_task.delay(str(scan.id), str(scan.organization_id))
         scan.celery_task_id = task.id
         await db.flush()
     except Exception as exc:

--- a/packages/api/app/routers/schedules.py
+++ b/packages/api/app/routers/schedules.py
@@ -204,6 +204,8 @@ async def trigger_schedule(
 
     from app.tasks.scan_tasks import run_scheduled_scan_task
 
-    task = run_scheduled_scan_task.delay(str(schedule.id))
+    task = run_scheduled_scan_task.delay(
+        str(schedule.id), str(schedule.organization_id)
+    )
 
     return {"task_id": task.id, "status": "queued", "schedule_id": str(schedule_id)}

--- a/packages/api/app/tasks/scan_tasks.py
+++ b/packages/api/app/tasks/scan_tasks.py
@@ -8,30 +8,38 @@ import uuid
 from datetime import datetime, timezone
 
 from app.tasks.celery_app import celery_app
-from app.database import async_session_factory
+from app.database import async_session_factory, set_rls_org_context
 
 logger = logging.getLogger(__name__)
 
 
 @celery_app.task(bind=True, max_retries=2, acks_late=True)
-def run_scan_task(self, scan_id: str) -> dict:
-    """Celery task that executes a scan asynchronously."""
+def run_scan_task(self, scan_id: str, org_id: str | None = None) -> dict:
+    """Celery task that executes a scan asynchronously.
+
+    org_id is the scan's organization; it sets the RLS context so the task can
+    read/write its tenant's rows under a non-superuser DB role (H5). Callers
+    should pass it; None keeps the legacy/superuser path working unchanged.
+    """
     logger.info("Starting Celery task for scan %s", scan_id)
     try:
-        result = asyncio.run(_run_scan(scan_id))
+        result = asyncio.run(_run_scan(scan_id, org_id))
         return result
     except Exception as exc:
         logger.error("Scan task %s failed: %s", scan_id, exc)
         raise self.retry(exc=exc, countdown=30)
 
 
-async def _run_scan(scan_id: str) -> dict:
+async def _run_scan(scan_id: str, org_id: str | None = None) -> dict:
     from app.models.finding import Finding
     from app.models.scan import Scan
     from app.models.scan_result import ScanResult as ScanResultModel
     from app.services.scan_service import ScanService
 
     async with async_session_factory() as db:
+        # H5: set the RLS org context before the first tenant-scoped query so the
+        # scan + its findings are visible/writable under a non-superuser role.
+        await set_rls_org_context(db, org_id)
         # Load scan
         try:
             scan_uuid = uuid.UUID(scan_id)
@@ -149,17 +157,20 @@ async def _run_scan(scan_id: str) -> dict:
 
 
 @celery_app.task(bind=True)
-def run_scheduled_scan_task(self, schedule_id: str):
+def run_scheduled_scan_task(self, schedule_id: str, org_id: str | None = None):
     """Run a scan from a schedule definition."""
-    asyncio.run(_run_scheduled_scan(schedule_id))
+    asyncio.run(_run_scheduled_scan(schedule_id, org_id))
 
 
-async def _run_scheduled_scan(schedule_id: str):
+async def _run_scheduled_scan(schedule_id: str, org_id: str | None = None):
     from app.models.scan_schedule import ScanSchedule
     from app.models.asset import Asset
     from app.models.scan import Scan
 
     async with async_session_factory() as db:
+        # H5: scope to the schedule's org so the schedule/assets/new-scan rows
+        # are visible/writable under a non-superuser role.
+        await set_rls_org_context(db, org_id)
         try:
             sched_uuid = uuid.UUID(schedule_id)
         except (ValueError, AttributeError):
@@ -227,8 +238,8 @@ async def _run_scheduled_scan(schedule_id: str):
         schedule.last_run_at = datetime.now(timezone.utc)
         await db.commit()
 
-    # Run the scan
-    await _run_scan(str(scan.id))
+    # Run the scan (same org as the schedule).
+    await _run_scan(str(scan.id), org_id)
 
 
 @celery_app.task
@@ -250,7 +261,9 @@ async def _check_schedules():
         now = datetime.now(timezone.utc)
         for schedule in schedules:
             if _should_run(schedule.cron_expression, schedule.last_run_at, now):
-                run_scheduled_scan_task.delay(str(schedule.id))
+                run_scheduled_scan_task.delay(
+                    str(schedule.id), str(schedule.organization_id)
+                )
 
 
 def _should_run(cron_expr: str, last_run, now) -> bool:

--- a/packages/api/tests/test_rls_context.py
+++ b/packages/api/tests/test_rls_context.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+"""H5: set_rls_org_context sets the worker's RLS org context session-scoped
+(survives the multiple commits a task issues) and no-ops when no org is given."""
+import asyncio
+from unittest.mock import AsyncMock
+
+from app.database import set_rls_org_context
+
+
+def test_sets_org_session_scoped():
+    db = AsyncMock()
+    asyncio.run(set_rls_org_context(db, "org-123"))
+    sqls = [str(c.args[0]) for c in db.execute.call_args_list]
+    assert any("app.current_org_id" in s for s in sqls)
+    # is_local => false: session-scoped so it isn't cleared by the task's commits.
+    assert any("false" in s for s in sqls)
+    assert all("true" not in s for s in sqls)
+
+
+def test_sets_user_when_given():
+    db = AsyncMock()
+    asyncio.run(set_rls_org_context(db, "org-1", user_id="user-9"))
+    sqls = " ".join(str(c.args[0]) for c in db.execute.call_args_list)
+    assert "app.current_org_id" in sqls and "app.current_user_id" in sqls
+
+
+def test_noop_when_org_none():
+    db = AsyncMock()
+    asyncio.run(set_rls_org_context(db, None))
+    db.execute.assert_not_called()


### PR DESCRIPTION
First **additive** slice of the H5 RLS-least-privilege epic (#140).

## Problem
The worker has no request context, so under a `NOSUPERUSER NOBYPASSRLS` DB role every tenant-scoped query returns **0 rows** (and the audit-log purge deletes 0). Today it works only because the app connects as a superuser (RLS bypassed).

## This PR (foundation)
- **`database.set_rls_org_context(session, org_id, user_id=None)`** — sets `app.current_org_id` on a worker session. **Session-scoped** `set_config(..., is_local => false)` (not transaction-scoped) so it survives the **multiple commits** a task issues; safe because the worker runs **NullPool** (fresh conn per task → no cross-tenant leak). No-op when org_id is None.
- **`run_scan_task` / `run_scheduled_scan_task`** take `org_id`; routers (`scans`, `schedules`) + the beat sweep pass the entity's `organization_id`, setting context **before** the first query (solves the chicken-and-egg where `_run_scan` loaded the scan before knowing its org).
- **`infra/docker/initdb/01-create-app-role.sql`** — the `NOSUPERUSER NOBYPASSRLS` role + grants.

**Fully additive + no-op under today's superuser role.**

## Verification
- `ruff` + `py_compile` clean; **30/30** (`test_rls_context.py` + RS256 + RLS-migration regression).
- **Not validated live** (the point of #140): real RLS behavior under the non-superuser role needs a live Postgres + the new role.

## Remaining H5 (specced on #140)
Cross-tenant sweep refactor (per-org loops), `report_tasks` threading, **L1** predicate scoping, **API-key** RLS context, **M2** append-only audit log, `DATABASE_URL` switch + migration-role separation.

## Acceptance test (yours, live)
Provision `nis2_app`, point API+worker `DATABASE_URL` at it, run two back-to-back scans → both persist findings; org A can't read org B via any worker path.