### PR TITLE
feat(api): scope report task to its org for RLS (H5, part 2)

### DIFF
--- a/packages/api/app/tasks/report_tasks.py
+++ b/packages/api/app/tasks/report_tasks.py
@@ -203,13 +203,17 @@ async def _generate_report(
     format: str,
     locale: str | None = None,
 ) -> dict:
-    from app.database import async_session_factory
+    from app.database import async_session_factory, set_rls_org_context
     from app.models.scan import Scan
     from app.models.scan_result import ScanResult
     from app.models.finding import Finding
     from sqlalchemy import select
 
     async with async_session_factory() as db:
+        # H5: the worker has no request context, so scope this session to the
+        # requesting org before any tenant-scoped read. No-op under the current
+        # superuser role; required once the app role is NOSUPERUSER NOBYPASSRLS.
+        await set_rls_org_context(db, org_id)
         scan = await db.get(Scan, uuid.UUID(scan_id))
         if not scan:
             raise ValueError(f"Scan {scan_id} not found")


### PR DESCRIPTION
**H5 part 2**, stacked on #155 (base retargets to main when #155 merges).

`generate_report_task` runs in the worker (no request context) and reads the scan + results + findings — all tenant-scoped. It already receives `org_id`, so this just calls `set_rls_org_context(db, org_id)` on the worker session before those reads, so they return rows under a `NOSUPERUSER NOBYPASSRLS` app role instead of an empty set.

- Additive + **no-op under the current superuser role**.
- `cleanup_old_reports` left as-is — it only prunes files, no tenant query.

Verified: `py_compile` + `ruff` clean; helper import resolves. Live validation (non-superuser PG) tracked on #140 with the rest of H5.