### PR TITLE
feat(api): scope report task to its org for RLS (H5, part 2)

### DIFF
--- a/packages/api/app/tasks/report_tasks.py
+++ b/packages/api/app/tasks/report_tasks.py
@@ -203,13 +203,17 @@ async def _generate_report(
     format: str,
     locale: str | None = None,
 ) -> dict:
-    from app.database import async_session_factory
+    from app.database import async_session_factory, set_rls_org_context
     from app.models.scan import Scan
     from app.models.scan_result import ScanResult
     from app.models.finding import Finding
     from sqlalchemy import select
 
     async with async_session_factory() as db:
+        # H5: the worker has no request context, so scope this session to the
+        # requesting org before any tenant-scoped read. No-op under the current
+        # superuser role; required once the app role is NOSUPERUSER NOBYPASSRLS.
+        await set_rls_org_context(db, org_id)
         scan = await db.get(Scan, uuid.UUID(scan_id))
         if not scan:
             raise ValueError(f"Scan {scan_id} not found")


### PR DESCRIPTION
H5 part 2 (replaces #158, auto-closed when #155's branch was deleted). `generate_report_task` runs in the worker and reads scan+results+findings; it already gets `org_id`, so call `set_rls_org_context` before those reads so they return rows under a NOSUPERUSER NOBYPASSRLS role. Additive + no-op under the current superuser role. **Validated live** (see #160): report generation works under nis2_app.