### PR TITLE
feat(tooling): local check/deploy/test mirror of CI + H5 live validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # NIS2 Compliance Platform — https://github.com/fabriziosalmi/nis2-public
 
-.PHONY: dev dev-up dev-up-fresh dev-down dev-logs api-logs web-logs db-migrate db-upgrade db-seed test test-api test-scanner lint clean clean-all prod prod-preflight prod-up prod-down
+.PHONY: dev dev-up dev-up-fresh dev-down dev-logs api-logs web-logs db-migrate db-upgrade db-seed test test-api test-scanner lint check test-integration test-e2e test-web h5-validate verify clean clean-all prod prod-preflight prod-up prod-down
 
 # ─── Cross-platform Python detection ─────────────────────────────────
 # v2.4.28: pre-2.4.28 the Makefile invoked `python` literally, which on
@@ -28,7 +28,13 @@
 # bash builtin and doesn't exist on `cmd.exe`; on Windows we use `where`
 # (cmd.exe / PowerShell builtin), elsewhere `command -v`. `firstword`
 # trims `where`'s multi-line output to the first hit.
-ifeq ($(OS),Windows_NT)
+# Prefer the project virtualenv (it has ruff/pytest/etc.) so `make lint/test/
+# check` work without activating it first; otherwise fall back to the
+# cross-platform interpreter detection. (venv/bin is POSIX; on Windows the
+# wildcard misses and we use the py launcher branch.)
+ifneq ($(wildcard venv/bin/python),)
+  PYTHON := venv/bin/python
+else ifeq ($(OS),Windows_NT)
   PYTHON := $(firstword $(shell where py 2>nul) $(shell where python3 2>nul) $(shell where python 2>nul))
 else
   PYTHON := $(firstword $(shell command -v python3 2>/dev/null) $(shell command -v python 2>/dev/null))
@@ -113,6 +119,54 @@ ifeq ($(strip $(PYTHON)),)
 	$(error $(PYTHON_NOT_FOUND_MSG))
 endif
 	cd packages/api && $(PYTHON) -m pytest tests/ -v
+
+# ─── Static checks (mirror CI; no running stack needed) ──────────────
+lint:
+ifeq ($(strip $(PYTHON)),)
+	$(error $(PYTHON_NOT_FOUND_MSG))
+endif
+	$(PYTHON) -m ruff check packages/scanner/nis2scan/ --select=E,W,F --ignore=E501
+	$(PYTHON) -m ruff check packages/api/app/ --select=E,W,F --ignore=E501
+
+# `check` = the CI gates that need no database: lint, the policy greps, and the
+# dependency audits. pip-audit is best-effort (skipped if not installed).
+check: lint
+	@echo "== policy: no bare 'except:' =="
+	@! grep -rn "^[[:space:]]*except:$$" --include="*.py" packages/ || (echo "  FAIL" && exit 1)
+	@echo "== policy: no CORS wildcard =="
+	@! grep -q 'allow_origins=\["\*"\]' packages/api/app/main.py || (echo "  FAIL" && exit 1)
+	@echo "== policy: .env not tracked =="
+	@! git ls-files --error-unmatch .env 2>/dev/null || (echo "  FAIL: .env is tracked" && exit 1)
+	@echo "== npm audit (web, prod deps, high) =="
+	cd packages/web && npm audit --omit=dev --audit-level=high
+	@command -v pip-audit >/dev/null 2>&1 && pip-audit --skip-editable || echo "  (pip-audit not installed — skipped)"
+	@echo "  static checks: OK"
+
+# ─── Tests that need the running dev stack (`make dev-up`) ────────────
+# Integration suite as the non-superuser nis2_app role on a dedicated nis2_test
+# DB (so RLS is actually enforced). See scripts/test_integration.sh.
+test-integration:
+	bash scripts/test_integration.sh
+
+# E2E live suite against the local stack. See scripts/test_e2e.sh.
+test-e2e:
+	bash scripts/test_e2e.sh
+
+# Next.js production build.
+test-web:
+	cd packages/web && npm run build
+
+# Prove Postgres RLS tenant isolation under nis2_app. See scripts/h5_validate.sh.
+h5-validate:
+	bash scripts/h5_validate.sh
+
+# One-shot local mirror of CI: static checks + unit suites first (fast, no
+# stack), then bring the stack up and run the stack-bound suites.
+verify: check test-scanner test-api test-web dev-up test-integration test-e2e
+	@echo ""
+	@echo "  LOCAL VERIFY: ALL GREEN"
+	@echo "  (run 'make h5-validate' for the RLS isolation proof on seeded data)"
+	@echo ""
 
 # ─── Production ──────────────────────────────────────────────────────
 prod: prod-up

--- a/infra/docker/docker-compose.dev.yml
+++ b/infra/docker/docker-compose.dev.yml
@@ -43,6 +43,10 @@ services:
       - ../../packages/api/app:/app/packages/api/app:ro
       - ../../packages/api/alembic:/app/packages/api/alembic
       - ../../packages/scanner/nis2scan:/app/packages/scanner/nis2scan:ro
+      # `make db-seed` runs `python -m scripts.seed` from WORKDIR
+      # /app/packages/api; the repo's scripts/ isn't otherwise in the
+      # image, so mount it here (read-only) or the target ModuleNotFounds.
+      - ../../scripts:/app/packages/api/scripts:ro
       # v2.4.19: shared volume for generated reports. The Celery
       # worker writes the rendered file under /tmp/nis2-reports;
       # the API's GET /reports/download/{task_id} reads from the

--- a/scripts/h5_validate.sh
+++ b/scripts/h5_validate.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# H5 — validate Postgres RLS tenant isolation under the least-privilege app role.
+#
+# Provisions nis2_app (NOSUPERUSER NOBYPASSRLS) via the init-SQL, then proves the
+# tenant_isolation policies actually filter for that role:
+#   * no org context      -> 0 rows (policy denies)
+#   * org A's context      -> only org A's rows
+#   * org B's context      -> none of org A's rows (cross-tenant read refused)
+#
+# This is the proof that isolation rests on the database, not just the app-layer
+# org_id filters. Run against the dev stack (`make dev-up`) with seeded data.
+#
+#   bash scripts/h5_validate.sh
+#
+# Env: NIS2_APP_PASSWORD (default h5validate), COMPOSE_FILE.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+COMPOSE_FILE="${COMPOSE_FILE:-infra/docker/docker-compose.dev.yml}"
+APP_PW="${NIS2_APP_PASSWORD:-h5validate}"
+DC=(docker compose -f "$COMPOSE_FILE")
+
+su()  { "${DC[@]}" exec -T postgres psql -U nis2 -d nis2 -tAX -c "$1" | tail -1; }
+# app() may run "SET ...; SELECT ..." in one session (the GUC must persist across
+# the two statements); psql prints the SET command tag first, so keep only the
+# final line — the SELECT's value.
+app() { "${DC[@]}" exec -T -e PGPASSWORD="$APP_PW" postgres psql -U nis2_app -d nis2 -tAX -c "$1" | tail -1; }
+
+fail=0
+check() { # label  actual  expected
+  if [ "$2" = "$3" ]; then printf '  \033[32mPASS\033[0m  %s (%s)\n' "$1" "$2"
+  else printf '  \033[31mFAIL\033[0m  %s: got "%s" expected "%s"\n' "$1" "$2" "$3"; fail=1; fi
+}
+
+echo "== 1. Provision nis2_app (init-SQL, idempotent) =="
+if "${DC[@]}" exec -T postgres psql -U nis2 -d nis2 -v app_pw="$APP_PW" \
+      < infra/docker/initdb/01-create-app-role.sql >/tmp/h5_provision.log 2>&1; then
+  echo "  provisioned"
+else
+  echo "  provision returned non-zero — last lines:"; tail -3 /tmp/h5_provision.log | sed 's/^/    /'
+fi
+
+echo "== 2. Role is least-privilege =="
+check "nis2_app NOSUPERUSER NOBYPASSRLS" \
+  "$(su "SELECT rolsuper::text||'/'||rolbypassrls::text FROM pg_roles WHERE rolname='nis2_app'")" "false/false"
+
+echo "== 3. RLS isolation proof =="
+ORG_A=$(su "SELECT organization_id FROM scans LIMIT 1")
+if [ -z "$ORG_A" ]; then
+  echo "  FAIL: no seeded scan to test against — run 'make db-seed' first"; exit 1
+fi
+# Prefer a real second org; fall back to a synthetic uuid (a 'tenant' that owns
+# nothing) so the isolation proof still holds with single-org seed data.
+ORG_B=$(su "SELECT id FROM organizations WHERE id <> '$ORG_A' LIMIT 1")
+[ -z "$ORG_B" ] && ORG_B=$(su "SELECT gen_random_uuid()")
+echo "  ORG_A (has scan) = $ORG_A"
+echo "  ORG_B (other)    = $ORG_B"
+A_SCANS=$(su "SELECT count(*) FROM scans    WHERE organization_id='$ORG_A'")
+A_FIND=$(su  "SELECT count(*) FROM findings WHERE organization_id='$ORG_A'")
+
+check "no-context scans=0"            "$(app 'SELECT count(*) FROM scans')"    "0"
+check "no-context findings=0"         "$(app 'SELECT count(*) FROM findings')" "0"
+check "orgA-context scans"            "$(app "SET app.current_org_id='$ORG_A'; SELECT count(*) FROM scans")"    "$A_SCANS"
+check "orgA-context findings"         "$(app "SET app.current_org_id='$ORG_A'; SELECT count(*) FROM findings")" "$A_FIND"
+check "orgB cannot see A's scans"     "$(app "SET app.current_org_id='$ORG_B'; SELECT count(*) FROM scans")"    "0"
+check "orgB cannot see A's findings"  "$(app "SET app.current_org_id='$ORG_B'; SELECT count(*) FROM findings")" "0"
+
+echo
+if [ "$fail" = 0 ]; then echo "H5 RLS VALIDATION: ALL CHECKS PASSED ✅"; else echo "H5 RLS VALIDATION: FAILURES ABOVE ❌"; fi
+exit $fail

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -13,7 +13,7 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
 async def seed():
-    from app.database import async_session_factory, engine
+    from app.database import Base, async_session_factory, engine
     from app.models import (
         Asset,
         Finding,
@@ -22,7 +22,6 @@ async def seed():
         Scan,
         User,
     )
-    from app.models.base import Base
 
     # Create all tables
     async with engine.begin() as conn:

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Run the E2E live suite (test_e2e_live.py) against the running dev stack.
+# Waits for API health, ensures the E2E user exists, then runs pytest. Mirrors
+# the ci.yml "e2e-tests" job but points at the local stack. Requires `make dev-up`.
+#
+#   bash scripts/test_e2e.sh [extra pytest args]
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+BASE="${E2E_LIVE_BASE_URL:-http://localhost:8000}"
+EMAIL="${E2E_LIVE_EMAIL:-e2e-ci@example.com}"
+PW="${E2E_LIVE_PASSWORD:-E2eC!password99}"
+PY="$ROOT/venv/bin/python"; [ -x "$PY" ] || PY="$(command -v python3)"
+
+echo "== wait for API health @ $BASE =="
+for _ in $(seq 1 30); do curl -sf "$BASE/api/v1/health" >/dev/null 2>&1 && break || sleep 1; done
+curl -sf "$BASE/api/v1/health" >/dev/null || { echo "API not healthy at $BASE — run 'make dev-up'"; exit 1; }
+
+echo "== ensure E2E user exists (201 created / 409 already there) =="
+curl -s -o /dev/null -w "  register: %{http_code}\n" -X POST "$BASE/api/v1/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PW\",\"full_name\":\"E2E CI User\",\"org_name\":\"E2E CI Org\"}" || true
+
+echo "== run E2E live suite =="
+cd packages/api
+E2E_LIVE_BASE_URL="$BASE" E2E_LIVE_EMAIL="$EMAIL" E2E_LIVE_PASSWORD="$PW" \
+  ENVIRONMENT=development PYTHONPATH=. "$PY" -m pytest tests/test_e2e_live.py "${@:--q}"

--- a/scripts/test_integration.sh
+++ b/scripts/test_integration.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Fabrizio Salmi <fabrizio.salmi@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Run the integration suite the way CI does: as the non-superuser, RLS-bound
+# nis2_app role against a dedicated nis2_test database (so the RLS policies are
+# actually enforced, not bypassed by a superuser). Mirrors the ci.yml
+# "integration-tests" job. Requires the dev stack up (`make dev-up`).
+#
+#   bash scripts/test_integration.sh [extra pytest args]
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+COMPOSE_FILE="${COMPOSE_FILE:-infra/docker/docker-compose.dev.yml}"
+APP_PW="${NIS2_APP_PASSWORD:-h5validate}"
+PGPORT_HOST="${PGPORT_HOST:-5433}"
+PY="$ROOT/venv/bin/python"; [ -x "$PY" ] || PY="$(command -v python3)"
+psql_su() { docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U nis2 "$@"; }
+
+echo "== provision nis2_test + nis2_app (NOSUPERUSER NOBYPASSRLS) =="
+psql_su -d nis2 -tAc "SELECT 1 FROM pg_database WHERE datname='nis2_test'" | grep -q 1 \
+  || psql_su -d nis2 -c "CREATE DATABASE nis2_test"
+psql_su -d nis2 -tAc "SELECT 1 FROM pg_roles WHERE rolname='nis2_app'" | grep -q 1 \
+  || psql_su -d nis2 -c "CREATE ROLE nis2_app WITH LOGIN PASSWORD '$APP_PW' NOSUPERUSER NOBYPASSRLS"
+# The suite runs Base.metadata.create_all itself, so the role needs DDL here
+# (unlike the prod init-SQL role, which is DML-only).
+psql_su -d nis2_test \
+  -c "GRANT ALL ON SCHEMA public TO nis2_app" \
+  -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO nis2_app" \
+  -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO nis2_app" >/dev/null
+
+echo "== run integration suite as nis2_app =="
+cd packages/api
+INTEGRATION_DB=1 ENVIRONMENT=development \
+  JWT_SECRET='integration-test-secret-must-be-at-least-32-chars-long-yes' \
+  CORS_ORIGINS='http://localhost:3000' \
+  DATABASE_URL="postgresql+asyncpg://nis2_app:${APP_PW}@localhost:${PGPORT_HOST}/nis2_test" \
+  DATABASE_URL_SYNC="postgresql://nis2_app:${APP_PW}@localhost:${PGPORT_HOST}/nis2_test" \
+  PYTHONPATH=. "$PY" -m pytest tests/test_integration.py "${@:--q}"


### PR DESCRIPTION
Replaces #160. Reusable `make check / test-integration / test-e2e / test-web / h5-validate / verify` against the docker dev stack, + fixes found running it on real Postgres (db-seed scripts/ mount; seed.py Base import). **Live validation: H5 RLS isolation proven under nis2_app** (psql + integration suite 10 passed as nis2_app); full local suite green (scanner 57, api 422, E2E 53, web build).