### PR TITLE
fix(dev): self-heal MFA/invite columns on pre-feature volumes

### DIFF
--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -183,6 +183,18 @@ async def ensure_schema() -> None:
         # NULL on existing rows = "never rotated" — the iat check
         # treats the token's iat as fresher than NULL automatically.
         ("users", "password_changed_at", "TIMESTAMP WITH TIME ZONE"),
+        # MFA / TOTP (migrations 003, 006) and invite-by-token (migration 004)
+        # were added to the User model after these tables may already exist on an
+        # upgraded volume. create_all does NOT backfill columns, so without these
+        # a dev who made their Postgres volume before the feature 500s on
+        # register/login with "column users.totp_secret does not exist" (found in
+        # the 2026-06-26 live validation). Types match the model + the migrations'
+        # end state. Prod is unaffected — it runs Alembic.
+        ("users", "totp_secret", "VARCHAR(256)"),
+        ("users", "totp_enabled", "BOOLEAN NOT NULL DEFAULT FALSE"),
+        ("users", "totp_recovery_codes", "VARCHAR(1024)"),
+        ("users", "invite_token_hash", "VARCHAR(128)"),
+        ("users", "invite_token_expires_at", "TIMESTAMP WITH TIME ZONE"),
     ]
     # v2.4.14: PasswordResetToken is a brand-new table; create_all above
     # already provisions it, no ALTER needed. Listed here for the


### PR DESCRIPTION
Self-heals the **dev** DB schema for Postgres volumes created before the MFA / invite features. Prod is unaffected (it uses Alembic).

## The fix
`ensure_schema().additive_columns` (the degraded-mode fallback that `ADD COLUMN IF NOT EXISTS` on `docker compose up`) was missing the `users` columns added after the table existed — TOTP/MFA (migrations 003, 006) and invite-by-token (004). `create_all` doesn't backfill columns, so a dev whose volume predates those features 500s on register/login with `column users.totp_secret does not exist`. Added the five (types match the model + migrations).

**Verified live:** drop the five → `docker compose up --force-recreate api` → ensure_schema re-adds **5/5**.

## Why this is *only* the additive fix (the alembic finding got deeper)
The companion "Alembic doesn't persist" chip turned out to be two coupled problems. Yes — `env.py` runs `SET LOCAL` before `begin_transaction()`, which autobegins a stray SQLAlchemy-2.0 transaction so the migration is silently rolled back. **But fixing that alone is unsafe:** `alembic revision --autogenerate` shows the **migrations are heavily drifted from the models** — ~11 missing columns plus dozens of VARCHAR-length / index / FK / NOT-NULL diffs (`001_initial` was hand-written and diverged). Making Alembic persist would apply the drifted migrations and build a *wrong* schema — the E2E proved it (register 500). The non-persistence was effectively *masking* the drift; `ensure_schema` (create_all from the models) is what actually builds a correct dev schema.

So the env.py fix + a migration-baseline regeneration are deferred to a separate task (both must land together). This PR ships only the safe additive_columns fix.