### PR TITLE
fix(web): method="post" on auth forms (no creds in URL pre-hydration)

### DIFF
--- a/packages/web/src/app/(auth)/forgot-password/page.tsx
+++ b/packages/web/src/app/(auth)/forgot-password/page.tsx
@@ -106,7 +106,8 @@ export default function ForgotPasswordPage() {
         <CardTitle className="text-2xl">{t("forgotPasswordPage.title")}</CardTitle>
         <CardDescription>{t("forgotPasswordPage.description")}</CardDescription>
       </CardHeader>
-      <form onSubmit={handleSubmit(onSubmit)}>
+      {/* method="post": a pre-hydration native submit must POST, not leak the email via a GET URL. */}
+      <form method="post" onSubmit={handleSubmit(onSubmit)}>
         <CardContent className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="email">{t("auth.email")}</Label>

--- a/packages/web/src/app/(auth)/login/page.tsx
+++ b/packages/web/src/app/(auth)/login/page.tsx
@@ -79,7 +79,9 @@ export default function LoginPage() {
         <CardTitle className="text-2xl">{t("auth.signInTitle")}</CardTitle>
         <CardDescription>{t("auth.signInDescription")}</CardDescription>
       </CardHeader>
-      <form onSubmit={handleSubmit(onSubmit)}>
+      {/* method="post" so a submit BEFORE hydration falls back to POST, not a
+          GET that would leak email/password into the URL (logs, history, Referer). */}
+      <form method="post" onSubmit={handleSubmit(onSubmit)}>
         <CardContent className="space-y-4">
           {sessionExpired && (
             <div className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">

--- a/packages/web/src/app/(auth)/register/page.tsx
+++ b/packages/web/src/app/(auth)/register/page.tsx
@@ -73,7 +73,8 @@ export default function RegisterPage() {
       {/* v2.4.23 audit a11y-14: aria-invalid + aria-describedby on
           every form field so SR users hear validation errors when
           they refocus the offending input. */}
-      <form onSubmit={handleSubmit(onSubmit)}>
+      {/* method="post": a pre-hydration native submit must POST, not leak creds via a GET URL. */}
+      <form method="post" onSubmit={handleSubmit(onSubmit)}>
         <CardContent className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="full_name">{t("auth.fullName")}</Label>

--- a/packages/web/src/app/(auth)/reset-password/page.tsx
+++ b/packages/web/src/app/(auth)/reset-password/page.tsx
@@ -141,7 +141,8 @@ function ResetPasswordInner() {
         <CardTitle className="text-2xl">{t("resetPasswordPage.title")}</CardTitle>
         <CardDescription>{t("resetPasswordPage.description")}</CardDescription>
       </CardHeader>
-      <form onSubmit={handleSubmit(onSubmit)}>
+      {/* method="post": a pre-hydration native submit must POST, not leak the new password via a GET URL. */}
+      <form method="post" onSubmit={handleSubmit(onSubmit)}>
         <CardContent className="space-y-4">
           {submitError && (
             <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">

--- a/packages/web/src/app/dashboard/settings/profile/page.tsx
+++ b/packages/web/src/app/dashboard/settings/profile/page.tsx
@@ -183,7 +183,8 @@ export default function ProfileSettingsPage() {
           <CardTitle>{t("changePassword")}</CardTitle>
         </CardHeader>
         <CardContent>
-          <form onSubmit={passwordForm.handleSubmit(onPasswordSubmit)} className="space-y-4">
+          {/* method="post": a pre-hydration native submit must POST, not leak the password via a GET URL. */}
+          <form method="post" onSubmit={passwordForm.handleSubmit(onPasswordSubmit)} className="space-y-4">
             <div className="space-y-2">
               <Label htmlFor="current_password">{t("currentPassword")}</Label>
               <Input id="current_password" type="password" autoComplete="current-password" {...passwordForm.register("current_password")} />


### PR DESCRIPTION
Closes chip `task_7e87de74`.

The auth forms submit via JS (react-hook-form `handleSubmit` → POST), but the `<form>` had **no `method`**, so it defaults to GET. A submit **before React hydration** (Enter/click) does the browser's native fallback = `GET /login?email=…&password=…` — **credentials in the URL** (server logs, browser history, Referer).

**Observed live 2026-06-26** in the dev logs: a real password in `GET /login?…&password=… 200`. Dev's slow first-compile widens the hydration window; the race exists in prod too for a fast Enter.

**Fix:** add `method="post"` to the credential-carrying forms — login, register, forgot-password, reset-password, and change-password (`settings/profile`). The JS `onSubmit` path is unchanged; `method` only governs the pre-hydration native fallback, which now POSTs (no creds in URL). Each carries a comment so it isn't "cleaned up" later.

**Verified:** `npm run build` green (all 5 routes compile); rendering of a literal form attribute is deterministic.
