### PR TITLE
feat(api): api_keys RLS exemption for the key lookup + scope the api-key path (H5)

### DIFF
--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -286,6 +286,30 @@ async def setup_row_level_security() -> None:
             "RLS: tenant_isolation policies verified on %d tables.", len(tenant_tables)
         )
 
+    # api_keys is a BOOTSTRAP table: get_api_key_org looks a key up BY key_hash to
+    # DISCOVER its org, so that query runs with no app.current_org_id set — and the
+    # org-scoped tenant_isolation policy would hide every row (0 results => every
+    # API-key request 401s under a NOBYPASSRLS role). Add a SELECT-only policy that
+    # permits the global hash lookup. PostgreSQL ORs permissive policies, so SELECT
+    # becomes global while tenant_isolation still scopes INSERT/UPDATE/DELETE to the
+    # caller's org. Hashes (not raw keys) are all that's readable, and the
+    # management endpoints filter by org in the query. Idempotent.
+    async with engine.begin() as conn:
+        try:
+            present = await conn.execute(
+                text(
+                    "SELECT 1 FROM pg_policies "
+                    "WHERE tablename='api_keys' AND policyname='api_keys_lookup'"
+                )
+            )
+            if present.first() is None:
+                await conn.execute(
+                    text("CREATE POLICY api_keys_lookup ON api_keys FOR SELECT USING (true)")
+                )
+                logger.info("RLS: api_keys_lookup (global SELECT) policy applied.")
+        except Exception as exc:
+            logger.warning("RLS: api_keys_lookup policy skipped: %s", exc)
+
     # Defence-in-depth: refuse to run with a SUPERUSER/BYPASSRLS role in prod
     # (shared with the Celery worker boot guard — see assert_db_role_rls_safe).
     await assert_db_role_rls_safe()

--- a/packages/api/app/dependencies.py
+++ b/packages/api/app/dependencies.py
@@ -316,6 +316,17 @@ async def get_api_key_org(
     api_key.last_used_at = now
     await db.flush()
 
+    # H5: the JWT path sets app.current_org_id via IdentityMiddleware + get_db,
+    # but an API-key request is not a JWT, so nothing scoped this session. Set the
+    # key's org now (transaction-scoped, like get_db's is_local=true for the pooled
+    # API connection) so the endpoint's tenant-scoped queries return rows under a
+    # NOSUPERUSER NOBYPASSRLS role. No-op on non-Postgres.
+    if IS_POSTGRES:
+        await db.execute(
+            text("SELECT set_config('app.current_org_id', :v, true)"),
+            {"v": str(api_key.organization_id)},
+        )
+
     return api_key, api_key.organization_id
 
 


### PR DESCRIPTION
H5 (#140), step 1 of the worker/auth least-privilege closeout. Under `nis2_app` (NOSUPERUSER NOBYPASSRLS) the API-key path broke two ways; both fixed + validated live.

1. **Bootstrap lookup** — `get_api_key_org` looks a key up BY `key_hash` to *discover* its org, so the query runs with no `app.current_org_id` and the org-scoped `tenant_isolation` policy hid every row → every API-key request 401'd. Added an **`api_keys_lookup` policy (FOR SELECT USING true)** in `setup_row_level_security`: SELECT is global for the lookup, while `tenant_isolation` still scopes INSERT/UPDATE/DELETE to the caller's org (permissive policies are OR'd; only hashes are readable, and the management endpoints filter by org).
2. **Endpoint scoping** — the JWT path sets the session org via IdentityMiddleware + get_db, but an API-key request isn't a JWT. `get_api_key_org` now sets `app.current_org_id` (transaction-scoped) after resolving the key.

**Validated live under `nis2_app` (no org context):** `api_keys` SELECT-by-hash → returns the row; `scans` → 0 (other tables still isolated); cross-tenant `api_keys` INSERT → rejected by `tenant_isolation` WITH CHECK. Additive / no-op under the current superuser role; full api-key-auth E2E proof comes with the DATABASE_URL switch (step A5).