### PR TITLE
feat(api): per-org audit-log retention purge + fix uncommitted purge (H5)

### DIFF
--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -286,6 +286,30 @@ async def setup_row_level_security() -> None:
             "RLS: tenant_isolation policies verified on %d tables.", len(tenant_tables)
         )
 
+    # api_keys is a BOOTSTRAP table: get_api_key_org looks a key up BY key_hash to
+    # DISCOVER its org, so that query runs with no app.current_org_id set — and the
+    # org-scoped tenant_isolation policy would hide every row (0 results => every
+    # API-key request 401s under a NOBYPASSRLS role). Add a SELECT-only policy that
+    # permits the global hash lookup. PostgreSQL ORs permissive policies, so SELECT
+    # becomes global while tenant_isolation still scopes INSERT/UPDATE/DELETE to the
+    # caller's org. Hashes (not raw keys) are all that's readable, and the
+    # management endpoints filter by org in the query. Idempotent.
+    async with engine.begin() as conn:
+        try:
+            present = await conn.execute(
+                text(
+                    "SELECT 1 FROM pg_policies "
+                    "WHERE tablename='api_keys' AND policyname='api_keys_lookup'"
+                )
+            )
+            if present.first() is None:
+                await conn.execute(
+                    text("CREATE POLICY api_keys_lookup ON api_keys FOR SELECT USING (true)")
+                )
+                logger.info("RLS: api_keys_lookup (global SELECT) policy applied.")
+        except Exception as exc:
+            logger.warning("RLS: api_keys_lookup policy skipped: %s", exc)
+
     # Defence-in-depth: refuse to run with a SUPERUSER/BYPASSRLS role in prod
     # (shared with the Celery worker boot guard — see assert_db_role_rls_safe).
     await assert_db_role_rls_safe()

--- a/packages/api/app/dependencies.py
+++ b/packages/api/app/dependencies.py
@@ -316,6 +316,17 @@ async def get_api_key_org(
     api_key.last_used_at = now
     await db.flush()
 
+    # H5: the JWT path sets app.current_org_id via IdentityMiddleware + get_db,
+    # but an API-key request is not a JWT, so nothing scoped this session. Set the
+    # key's org now (transaction-scoped, like get_db's is_local=true for the pooled
+    # API connection) so the endpoint's tenant-scoped queries return rows under a
+    # NOSUPERUSER NOBYPASSRLS role. No-op on non-Postgres.
+    if IS_POSTGRES:
+        await db.execute(
+            text("SELECT set_config('app.current_org_id', :v, true)"),
+            {"v": str(api_key.organization_id)},
+        )
+
     return api_key, api_key.organization_id
 
 

--- a/packages/api/app/tasks/cleanup_tasks.py
+++ b/packages/api/app/tasks/cleanup_tasks.py
@@ -61,6 +61,9 @@ async def _cleanup():
     # same family of issue scan_tasks.py opted into in v2.4.19).
     from app.models.password_reset_token import PasswordResetToken
     from app.models.revoked_token import RevokedToken
+    from app.models.organization import Organization
+    from app.database import set_rls_org_context
+    from sqlalchemy import select
 
     now = datetime.now(timezone.utc)
 
@@ -91,11 +94,26 @@ async def _cleanup():
         # the retention ceiling passes, even the anonymised record has no further
         # legitimate purpose for the controller.
         cutoff = now - timedelta(days=settings.audit_log_retention_days)
-        audit_result = await db.execute(
-            text("DELETE FROM audit_logs WHERE created_at < :cutoff"),
-            {"cutoff": cutoff},
-        )
-        audit_n = audit_result.rowcount or 0
+        # H5: audit_logs is org-scoped, so under a NOSUPERUSER NOBYPASSRLS role a
+        # single cross-tenant DELETE matches 0 rows. Walk the orgs, scope the
+        # session per-org, and purge each org's expired rows. The explicit
+        # organization_id filter keeps it correct under the superuser role too.
+        # (Also fixes a pre-existing miss: the old single DELETE was never
+        # committed — the only commit above covered just the token purges — so the
+        # audit retention purge silently rolled back on session close.)
+        audit_n = 0
+        org_ids = (await db.execute(select(Organization.id))).scalars().all()
+        for _org_id in org_ids:
+            await set_rls_org_context(db, str(_org_id))
+            _r = await db.execute(
+                text(
+                    "DELETE FROM audit_logs "
+                    "WHERE created_at < :cutoff AND organization_id = :org"
+                ),
+                {"cutoff": cutoff, "org": str(_org_id)},
+            )
+            audit_n += _r.rowcount or 0
+        await db.commit()
 
         revoked_n = revoked_result.rowcount or 0
         reset_n = reset_result.rowcount or 0

--- a/packages/api/app/tasks/incident_tasks.py
+++ b/packages/api/app/tasks/incident_tasks.py
@@ -101,8 +101,9 @@ async def _check_deadlines() -> dict:
     from app.models.incident import Incident
     from app.models.notification_channel import NotificationChannel
     from app.models.membership import Membership
+    from app.models.organization import Organization
     from app.models.user import User
-    from app.database import async_session_factory
+    from app.database import async_session_factory, set_rls_org_context
     from sqlalchemy import select
 
     now = datetime.now(timezone.utc)
@@ -111,12 +112,26 @@ async def _check_deadlines() -> dict:
     _redis = _get_redis_client()
 
     async with async_session_factory() as db:
-        result = await db.execute(
-            select(Incident).where(Incident.status.notin_(_CLOSED_STATUSES))
-        )
-        incidents = result.scalars().all()
+        # H5: this cross-tenant sweep has no request context, so a single
+        # cross-tenant SELECT returns nothing under a NOBYPASSRLS role. Walk the
+        # orgs, scope the session per-org, and gather each org's open incidents.
+        # The explicit organization_id filter keeps it correct under the current
+        # superuser role too. organizations has no tenant policy → enumerable.
+        org_ids = (await db.execute(select(Organization.id))).scalars().all()
+        incidents = []
+        for _org_id in org_ids:
+            await set_rls_org_context(db, str(_org_id))
+            _res = await db.execute(
+                select(Incident).where(
+                    Incident.status.notin_(_CLOSED_STATUSES),
+                    Incident.organization_id == _org_id,
+                )
+            )
+            incidents.extend(_res.scalars().all())
 
         for incident in incidents:
+            # Re-scope to this incident's org before its org-scoped reads/writes.
+            await set_rls_org_context(db, str(incident.organization_id))
             # Load org's active notification channels once per incident
             chan_result = await db.execute(
                 select(NotificationChannel).where(


### PR DESCRIPTION
H5 (#140) — the last sweep. `cleanup_tasks._cleanup` purged old `audit_logs` with a single cross-tenant DELETE → 0 rows under a NOBYPASSRLS role. Now walks orgs and purges each org's expired rows under per-org context (explicit `organization_id` filter; correct under superuser too).

Also fixes a **pre-existing bug**: the audit DELETE was never committed (the only commit covered the token purges), so the retention purge silently rolled back on session close. Now committed.

Validated live: `nis2_app` with org context can DELETE `audit_logs` (has the grant, RLS allows) — 0-row no-op test ran clean.