### PR TITLE
feat(api): audit_logs append-only for the app role + SECURITY DEFINER purge (M2)

### DIFF
--- a/infra/docker/initdb/01-create-app-role.sql
+++ b/infra/docker/initdb/01-create-app-role.sql
@@ -45,9 +45,12 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT USAGE, SELECT ON SEQUENCES TO nis2_app;
 
--- 3. (M2 — append-only audit log) Enable ONCE the audit-log retention purge in
---    cleanup_tasks runs under a separate maintenance role (or a SECURITY DEFINER
---    function); otherwise the purge silently deletes 0 rows. Until then, leave
---    commented so the existing cleanup keeps working.
---
---   REVOKE UPDATE, DELETE ON audit_logs FROM nis2_app;
+-- 3. (M2 — append-only audit log) ENFORCED at app boot in
+--    app.database.setup_row_level_security, NOT here. Both the REVOKE and the
+--    purge helper reference audit_logs, which does not exist yet on first volume
+--    init (the app builds the schema on its first boot). setup_row_level_security
+--    — run as the superuser/migration role — creates a SECURITY DEFINER
+--    purge_old_audit_logs() function, restricts its EXECUTE to nis2_app, then
+--    runs `REVOKE UPDATE, DELETE ON audit_logs FROM nis2_app`. cleanup_tasks
+--    calls that function so the retention purge keeps working under the
+--    append-only role (it bypasses RLS and keeps DELETE as the definer).

--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -310,6 +310,49 @@ async def setup_row_level_security() -> None:
         except Exception as exc:
             logger.warning("RLS: api_keys_lookup policy skipped: %s", exc)
 
+    # M2: make audit_logs append-only for the application role. A plain REVOKE
+    # would also break the retention purge in cleanup_tasks, so that purge runs
+    # through purge_old_audit_logs() — a SECURITY DEFINER function owned by this
+    # (privileged) setup role: it bypasses RLS and keeps DELETE even after the app
+    # role loses it. SET search_path guards the definer fn against search-path
+    # hijacking; EXECUTE is revoked from PUBLIC (the CREATE default) then granted
+    # only to the app role. Each statement runs in its own transaction so a no-op
+    # (role absent, or insufficient rights once running AS the app role) doesn't
+    # abort the rest — these must be applied during a superuser/migration boot.
+    _audit_appendonly_stmts = (
+        (
+            "CREATE OR REPLACE FUNCTION purge_old_audit_logs(retention_days integer) "
+            "RETURNS bigint LANGUAGE plpgsql SECURITY DEFINER "
+            "SET search_path = public, pg_temp AS $fn$ "
+            "DECLARE deleted bigint; "
+            "BEGIN "
+            "DELETE FROM audit_logs "
+            "WHERE created_at < now() - make_interval(days => retention_days); "
+            "GET DIAGNOSTICS deleted = ROW_COUNT; "
+            "RETURN deleted; "
+            "END; $fn$",
+            "purge_old_audit_logs() function",
+        ),
+        (
+            "REVOKE EXECUTE ON FUNCTION purge_old_audit_logs(integer) FROM PUBLIC",
+            "lock down purge function (revoke EXECUTE from PUBLIC)",
+        ),
+        (
+            "GRANT EXECUTE ON FUNCTION purge_old_audit_logs(integer) TO nis2_app",
+            "grant purge EXECUTE to nis2_app",
+        ),
+        (
+            "REVOKE UPDATE, DELETE ON audit_logs FROM nis2_app",
+            "make audit_logs append-only for nis2_app",
+        ),
+    )
+    for _stmt, _desc in _audit_appendonly_stmts:
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(text(_stmt))
+        except Exception as exc:
+            logger.warning("M2: %s skipped: %s", _desc, exc)
+
     # Defence-in-depth: refuse to run with a SUPERUSER/BYPASSRLS role in prod
     # (shared with the Celery worker boot guard — see assert_db_role_rls_safe).
     await assert_db_role_rls_safe()

--- a/packages/api/app/tasks/cleanup_tasks.py
+++ b/packages/api/app/tasks/cleanup_tasks.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from sqlalchemy import delete, text
 
@@ -61,9 +61,6 @@ async def _cleanup():
     # same family of issue scan_tasks.py opted into in v2.4.19).
     from app.models.password_reset_token import PasswordResetToken
     from app.models.revoked_token import RevokedToken
-    from app.models.organization import Organization
-    from app.database import set_rls_org_context
-    from sqlalchemy import select
 
     now = datetime.now(timezone.utc)
 
@@ -93,26 +90,17 @@ async def _cleanup():
         # the event type still provides forensic value after erasure, but once
         # the retention ceiling passes, even the anonymised record has no further
         # legitimate purpose for the controller.
-        cutoff = now - timedelta(days=settings.audit_log_retention_days)
-        # H5: audit_logs is org-scoped, so under a NOSUPERUSER NOBYPASSRLS role a
-        # single cross-tenant DELETE matches 0 rows. Walk the orgs, scope the
-        # session per-org, and purge each org's expired rows. The explicit
-        # organization_id filter keeps it correct under the superuser role too.
-        # (Also fixes a pre-existing miss: the old single DELETE was never
-        # committed — the only commit above covered just the token purges — so the
-        # audit retention purge silently rolled back on session close.)
-        audit_n = 0
-        org_ids = (await db.execute(select(Organization.id))).scalars().all()
-        for _org_id in org_ids:
-            await set_rls_org_context(db, str(_org_id))
-            _r = await db.execute(
-                text(
-                    "DELETE FROM audit_logs "
-                    "WHERE created_at < :cutoff AND organization_id = :org"
-                ),
-                {"cutoff": cutoff, "org": str(_org_id)},
-            )
-            audit_n += _r.rowcount or 0
+        # M2: audit_logs is append-only for the application role, so the retention
+        # purge runs through purge_old_audit_logs() — a SECURITY DEFINER function
+        # owned by a privileged role that bypasses RLS and retains DELETE. One
+        # statement purges every org's expired rows (it computes the cutoff from
+        # audit_log_retention_days internally). Still committed explicitly — the
+        # commit above covered only the token purges.
+        audit_res = await db.execute(
+            text("SELECT purge_old_audit_logs(:days)"),
+            {"days": settings.audit_log_retention_days},
+        )
+        audit_n = audit_res.scalar() or 0
         await db.commit()
 
         revoked_n = revoked_result.rowcount or 0

--- a/packages/api/tests/test_audit_log_erasure.py
+++ b/packages/api/tests/test_audit_log_erasure.py
@@ -69,11 +69,14 @@ class TestCleanupTasksReturnShape:
             "cleanup_tasks._cleanup() must return an 'audit_logs' count"
         )
 
-    def test_audit_logs_delete_uses_cutoff(self) -> None:
+    def test_audit_logs_purge_uses_retention(self) -> None:
         import pathlib
         src = pathlib.Path("app/tasks/cleanup_tasks.py").read_text()
         assert "audit_logs" in src
-        assert "cutoff" in src
+        # M2: audit_logs is append-only for the app role, so the retention purge
+        # runs through the SECURITY DEFINER purge_old_audit_logs() function — the
+        # cutoff is computed inside it from the retention setting.
+        assert "purge_old_audit_logs" in src
         assert "audit_log_retention_days" in src
 
 


### PR DESCRIPTION
**M2** (draconian review). The `audit_logs` RLS policy had no `FOR` clause, so the application role could UPDATE/DELETE audit rows — the trail wasn't append-only. A plain REVOKE would break the retention purge in `cleanup_tasks`, so the purge moves behind a privileged function:

- `setup_row_level_security` creates a **`SECURITY DEFINER purge_old_audit_logs(days)`** function (owned by the privileged setup role — bypasses RLS, keeps DELETE), `SET search_path` hardened, **EXECUTE revoked from PUBLIC** then granted only to `nis2_app`; then **`REVOKE UPDATE, DELETE ON audit_logs FROM nis2_app`**.
- `cleanup_tasks._cleanup` calls the function instead of a direct DELETE (drops the now-unused per-org loop from #171 + its imports).
- init-SQL comment updated (M2 is enforced at boot in `setup_row_level_security`, not the first-init script — the table doesn't exist that early).

**Validated live under `nis2_app`:**
```
UPDATE / DELETE on audit_logs        → permission denied      (append-only ✓)
INSERT audit_logs (with ctx)         → INSERT 0 1             (append still works ✓)
purge_old_audit_logs(90) via nis2_app→ returned 1, row purged (retention works ✓)
function ACL                         → {nis2, nis2_app} only  (PUBLIC removed ✓)
```
20 audit-erasure/cleanup unit tests + 16 rls-migration tests green.

> **Scope note:** the GDPR-erasure path (`auth.py`) still does a direct `UPDATE audit_logs` (pseudonymisation) + cross-org DELETEs. Those break under `nis2_app` and belong to the separate `DATABASE_URL`-switch epic (each needs its own SECURITY DEFINER / per-org handling). Under the current **superuser** deploy the erasure is unaffected (superuser retains all privileges).