### PR TITLE
fix(web): per-request nonce CSP so prod hydration isn't blocked (L12)

### DIFF
--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -53,23 +53,12 @@ const config: NextConfig = {
     ]
   },
   async headers() {
-    // Next.js dev mode (React Refresh + webpack HMR) compiles modules client-
-    // side via `new Function()` / `eval`, which a strict CSP without
-    // 'unsafe-eval' blocks. We only loosen the policy in development; the
-    // production build is fully pre-compiled and keeps the tight policy.
-    const isDev = process.env.NODE_ENV !== 'production'
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
-    const scriptSrc = isDev
-      ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
-      // P1-09 audit fix: production CSP drops 'unsafe-inline'. Next.js
-      // standalone builds are fully pre-compiled — no inline scripts.
-      // Pre-fix, 'unsafe-inline' neutralised CSP's XSS protection
-      // entirely: any attacker who could inject HTML could also inject
-      // and execute <script> blocks. Dev mode keeps it for HMR.
-      : "script-src 'self'"
-    const connectSrc = isDev
-      ? `connect-src 'self' ${apiUrl} ws: wss:`
-      : `connect-src 'self' ${apiUrl}`
+    // The Content-Security-Policy is set per-request in src/middleware.ts so it
+    // can carry a nonce for Next's inline hydration scripts (App Router emits
+    // them; a static `script-src 'self'` blocked them in prod -> no hydration).
+    // It must live in exactly one place: a second static CSP here would be
+    // intersected with the middleware one and its missing nonce would block the
+    // nonced scripts. The static security headers below apply to every route.
     return [
       {
         source: '/(.*)',
@@ -93,20 +82,6 @@ const config: NextConfig = {
           {
             key: 'Permissions-Policy',
             value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()',
-          },
-          {
-            key: 'Content-Security-Policy',
-            value: [
-              "default-src 'self'",
-              scriptSrc,
-              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-              "font-src 'self' https://fonts.gstatic.com",
-              "img-src 'self' data: blob: https:",
-              connectSrc,
-              "frame-ancestors 'none'",
-              "base-uri 'self'",
-              "form-action 'self'",
-            ].join('; '),
           },
           {
             key: 'Strict-Transport-Security',

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import "./globals.css"
 import { Providers } from "@/components/layout/providers"
 import { NextIntlClientProvider } from "next-intl"
 import { getLocale, getMessages } from "next-intl/server"
+import { headers } from "next/headers"
 
 const sansFont = Manrope({ subsets: ["latin"], variable: "--font-sans" })
 const monoFont = JetBrains_Mono({ subsets: ["latin"], variable: "--font-mono" })
@@ -26,6 +27,11 @@ export const metadata: Metadata = {
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const locale = await getLocale()
   const messages = await getMessages()
+  // CSP nonce minted per-request in middleware.ts — hand it to next-themes so
+  // its pre-hydration inline theme script carries the nonce. Without it the
+  // strict prod CSP blocks that one script: a flash of the wrong theme + a
+  // console CSP error (every other inline script is nonced by Next itself).
+  const nonce = (await headers()).get("x-nonce") ?? undefined
 
   return (
     // suppressHydrationWarning on <html> covers next-themes' class swap.
@@ -41,7 +47,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         suppressHydrationWarning
       >
         <NextIntlClientProvider messages={messages}>
-          <Providers>{children}</Providers>
+          <Providers nonce={nonce}>{children}</Providers>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/packages/web/src/components/layout/providers.tsx
+++ b/packages/web/src/components/layout/providers.tsx
@@ -41,7 +41,13 @@ function SessionExpiredHandler() {
   return null
 }
 
-export function Providers({ children }: { children: React.ReactNode }) {
+export function Providers({
+  children,
+  nonce,
+}: {
+  children: React.ReactNode
+  nonce?: string
+}) {
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -72,6 +78,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       defaultTheme="system"
       enableSystem
       disableTransitionOnChange
+      nonce={nonce}
     >
       <QueryClientProvider client={queryClient}>
         <TooltipProvider>

--- a/packages/web/src/middleware.ts
+++ b/packages/web/src/middleware.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server"
+
+/**
+ * Per-request nonce-based Content-Security-Policy (audit fix L12).
+ *
+ * Next.js App Router emits inline <script> tags for the RSC payload and
+ * hydration (self.__next_f.push(...)). A static `script-src 'self'` with no
+ * nonce blocks every one of them in production — the page renders but never
+ * hydrates, leaving a dead, non-interactive app. (This stayed latent because
+ * CI/E2E run in dev mode, where script-src keeps 'unsafe-inline'.)
+ *
+ * This mints a per-request nonce and hands it to Next via the request's
+ * Content-Security-Policy header; Next stamps that nonce onto the scripts it
+ * renders. `strict-dynamic` then lets those nonced bootstrap scripts pull in
+ * the /_next/static chunks. The same CSP is set on the response.
+ *
+ * Dev keeps 'unsafe-inline'/'unsafe-eval' (and NO nonce) because React Refresh
+ * + webpack HMR compile modules client-side via eval — and because a nonce in
+ * the policy makes the browser ignore 'unsafe-inline' entirely, which would
+ * break HMR's inline scripts.
+ *
+ * NOTE on the convention: Next 16.2 logs a deprecation suggesting the `proxy`
+ * file convention, but `proxy.ts` is NOT yet recognised by the build in this
+ * version (verified: no proxy is emitted, no nonce applied — the codemod ships
+ * only on @next/codemod@canary). We therefore stay on the supported, working
+ * `middleware` convention and migrate to `proxy` on a future Next upgrade.
+ */
+export function middleware(request: NextRequest) {
+  const isDev = process.env.NODE_ENV !== "production"
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
+
+  // Edge-runtime-safe random nonce (no Node Buffer in the edge runtime).
+  let nonce = ""
+  if (!isDev) {
+    const bytes = new Uint8Array(16)
+    crypto.getRandomValues(bytes)
+    let bin = ""
+    for (const b of bytes) bin += String.fromCharCode(b)
+    nonce = btoa(bin)
+  }
+
+  const scriptSrc = isDev
+    ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+    : `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`
+  const connectSrc = isDev
+    ? `connect-src 'self' ${apiUrl} ws: wss:`
+    : `connect-src 'self' ${apiUrl}`
+
+  // style-src keeps 'unsafe-inline': React renders inline `style=` ATTRIBUTES
+  // (e.g. severity-badge colors) which cannot carry a nonce, and CSS injection
+  // is not script execution. Adding a nonce here would make the browser ignore
+  // 'unsafe-inline' and break those attributes.
+  const csp = [
+    "default-src 'self'",
+    scriptSrc,
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "font-src 'self' https://fonts.gstatic.com",
+    "img-src 'self' data: blob: https:",
+    connectSrc,
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ].join("; ")
+
+  // Next reads the nonce from the request's CSP header and applies it to the
+  // scripts it renders; x-nonce lets our own server components read it too.
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set("content-security-policy", csp)
+  if (nonce) requestHeaders.set("x-nonce", nonce)
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } })
+  response.headers.set("content-security-policy", csp)
+  return response
+}
+
+export const config = {
+  matcher: [
+    // Run on documents, not static assets / the image optimizer / the API proxy
+    // (those don't execute inline scripts). Skip prefetches so a cached RSC
+    // prefetch never pins a stale nonce onto a later full navigation.
+    {
+      source: "/((?!api|_next/static|_next/image|favicon.ico).*)",
+      missing: [
+        { type: "header", key: "next-router-prefetch" },
+        { type: "header", key: "purpose", value: "prefetch" },
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
## L12 — per-request nonce CSP (and a latent prod-hydration bug)

### The bug
The production CSP set `script-src 'self'` with **no nonce**, on the assumption (per a code comment) that standalone builds emit no inline scripts. That's false for the App Router: every page ships **8–13 inline `<script>` tags** (the RSC `self.__next_f` payload + the hydration bootstrap). With `script-src 'self'` (no `'unsafe-inline'`, no nonce) the browser **blocks all of them** → the page renders but **never hydrates** in production.

It stayed latent because CI/E2E run in **dev** mode, where `script-src` keeps `'unsafe-inline'`. The strict policy only applies to a production build, which no test exercises.

### The fix
- **`src/middleware.ts`** mints a per-request nonce, hands it to Next via the request CSP header (Next stamps it onto every script it renders), and sets the response CSP to `script-src 'self' 'nonce-…' 'strict-dynamic'`. Dev keeps `'unsafe-inline'`/`'unsafe-eval'` (no nonce) for React Refresh + HMR.
- **`next.config.ts`** no longer sets the CSP (a static second CSP would be intersected with the nonce'd one and its missing nonce would block the scripts). The other security headers stay.
- **`layout.tsx`** reads the nonce (`x-nonce`) and passes it to **next-themes**' `ThemeProvider` so its pre-hydration inline theme script is nonced too — the one inline script Next doesn't nonce itself.
- `style-src` keeps `'unsafe-inline'`: React emits inline `style=` **attributes** that can't carry a nonce, and there are no inline `<style>` tags.

### Verification (served the production build)
```
              CSP script-src                         un-nonced inline scripts
/             'self' 'nonce-…' 'strict-dynamic'      0
/login        'self' 'nonce-…' 'strict-dynamic'      0
/register     'self' 'nonce-…' 'strict-dynamic'      0
/dashboard    'self' 'nonce-…' 'strict-dynamic'      0
```
Per-request nonce changes each load; every inline script carries it; no inline event handlers / `javascript:` URIs. Dev stack still serves HTTP 200 with the dev CSP.

> Next 16.2 logs a deprecation suggesting the `proxy` file convention, but `proxy.ts` is **not yet recognised by the build in this version** (verified: no proxy emitted, no nonce applied — the codemod ships only on `@next/codemod@canary`). Staying on the supported `middleware` convention; migrate on a future Next upgrade.
