### PR TITLE
fix(api): make the app run under the nis2_app least-privilege role (H5 switch)

### DIFF
--- a/docs/h5-rls-validation.md
+++ b/docs/h5-rls-validation.md
@@ -56,6 +56,13 @@ start **without** the "rolsuper/rolbypassrls — RLS bypassed" warning. If you s
 `Refusing to start: ... SUPERUSER/BYPASSRLS app role`, the app is still on the
 superuser URL.
 
+> **One-time superuser setup.** The RLS policies and the two `SECURITY DEFINER`
+> audit helpers (`purge_old_audit_logs`, `pseudonymize_user_audit_logs`) are
+> created by `setup_row_level_security` during a superuser/migration boot — run
+> that once before switching the app role. When the app later boots *as*
+> `nis2_app`, those CREATE/REVOKE/GRANT statements no-op (insufficient privilege,
+> caught) because the objects already exist.
+
 ## 3. Acceptance test
 
 The point is to prove isolation holds **even with the app-layer filters removed** —
@@ -82,9 +89,13 @@ i.e. the database itself refuses cross-tenant reads.
 Point `DATABASE_URL` back at the superuser URL and restart. Nothing in the schema
 changed, so this is instant and lossless.
 
-## What to report back
+## Status — VALIDATED (2026-06-27)
 
-Per the acceptance test: do manual scans + reports work under `nis2_app`, and does
-psql confirm 0 cross-tenant rows? Anything that breaks (especially scheduled scans
-or API-key auth) is expected until the remaining #140 chunks land — note which, so
-the per-org sweep / `api_keys` exemption can be prioritised.
+The full switch is proven on the local stack under `nis2_app`: the **E2E live
+suite passes 53/53**, plus register / login / scans / reports / API-key auth /
+GDPR erasure end-to-end. The per-org cross-tenant sweeps (#163 / #170 / #171),
+the `api_keys` RLS exemption (#169 / #174), M2 audit append-only (#172), and the
+bootstrap-write contexts (#174) have all landed — so nothing in the acceptance
+test above is "expected to break" anymore. The only step that still needs the
+superuser is the one-time schema + policy + SECURITY-DEFINER-function setup noted
+in §2.

--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -341,6 +341,31 @@ async def setup_row_level_security() -> None:
             "GRANT EXECUTE ON FUNCTION purge_old_audit_logs(integer) TO nis2_app",
             "grant purge EXECUTE to nis2_app",
         ),
+        # GDPR Art. 17 erasure pseudonymises a user's audit rows (UPDATE) — also a
+        # legitimate, privileged exception to append-only, so it runs through its
+        # own SECURITY DEFINER function (auth.py calls it instead of a direct
+        # UPDATE, which the REVOKE below would otherwise block under nis2_app).
+        (
+            "CREATE OR REPLACE FUNCTION pseudonymize_user_audit_logs(p_user_id uuid) "
+            "RETURNS bigint LANGUAGE plpgsql SECURITY DEFINER "
+            "SET search_path = public, pg_temp AS $fn$ "
+            "DECLARE updated bigint; "
+            "BEGIN "
+            "UPDATE audit_logs SET user_id = NULL, ip_address = '127.0.0.1', "
+            "user_agent = '[erased]', details = NULL WHERE user_id = p_user_id; "
+            "GET DIAGNOSTICS updated = ROW_COUNT; "
+            "RETURN updated; "
+            "END; $fn$",
+            "pseudonymize_user_audit_logs() function",
+        ),
+        (
+            "REVOKE EXECUTE ON FUNCTION pseudonymize_user_audit_logs(uuid) FROM PUBLIC",
+            "lock down pseudonymize function (revoke EXECUTE from PUBLIC)",
+        ),
+        (
+            "GRANT EXECUTE ON FUNCTION pseudonymize_user_audit_logs(uuid) TO nis2_app",
+            "grant pseudonymize EXECUTE to nis2_app",
+        ),
         (
             "REVOKE UPDATE, DELETE ON audit_logs FROM nis2_app",
             "make audit_logs append-only for nis2_app",

--- a/packages/api/app/dependencies.py
+++ b/packages/api/app/dependencies.py
@@ -301,6 +301,19 @@ async def get_api_key_org(
 
     now = datetime.now(timezone.utc)
 
+    # H5: an API-key request isn't a JWT, so IdentityMiddleware/get_db set no RLS
+    # context. Scope this session to the key's org NOW — BEFORE the is_active /
+    # last_used_at writes below and the endpoint's tenant-scoped queries — so they
+    # work under a NOSUPERUSER NOBYPASSRLS role. (The api_keys_lookup policy lets
+    # the hash lookup above run context-free; every api_keys WRITE after this is
+    # org-scoped and would otherwise match 0 rows -> StaleDataError.) Transaction-
+    # scoped (is_local=true), matching get_db's pooled-connection path.
+    if IS_POSTGRES:
+        await db.execute(
+            text("SELECT set_config('app.current_org_id', :v, true)"),
+            {"v": str(api_key.organization_id)},
+        )
+
     # Honor expires_at. Without this, a customer who issued a key with
     # `expires_at = now + 30d` to a contractor never had the key
     # actually expire. Defence-in-depth: also flip is_active=False so
@@ -315,17 +328,6 @@ async def get_api_key_org(
 
     api_key.last_used_at = now
     await db.flush()
-
-    # H5: the JWT path sets app.current_org_id via IdentityMiddleware + get_db,
-    # but an API-key request is not a JWT, so nothing scoped this session. Set the
-    # key's org now (transaction-scoped, like get_db's is_local=true for the pooled
-    # API connection) so the endpoint's tenant-scoped queries return rows under a
-    # NOSUPERUSER NOBYPASSRLS role. No-op on non-Postgres.
-    if IS_POSTGRES:
-        await db.execute(
-            text("SELECT set_config('app.current_org_id', :v, true)"),
-            {"v": str(api_key.organization_id)},
-        )
 
     return api_key, api_key.organization_id
 

--- a/packages/api/app/middleware/audit.py
+++ b/packages/api/app/middleware/audit.py
@@ -43,6 +43,14 @@ EXEMPT_PATHS = {
     "/api/v1/auth/logout",
 }
 
+# (method, path) pairs that can't be middleware-audited because the request
+# deletes the actor (and possibly their lone org): the audit row's user_id /
+# organization_id FK would dangle, so the INSERT always fails. Account erasure
+# does its own audit-trail handling — it pseudonymises the user's existing rows.
+EXEMPT_METHOD_PATHS = {
+    ("DELETE", "/api/v1/auth/me"),
+}
+
 
 async def log_action(
     db: AsyncSession,
@@ -108,6 +116,8 @@ class AuditMiddleware(BaseHTTPMiddleware):
         if request.method not in LOG_METHODS:
             return response
         if request.url.path in EXEMPT_PATHS:
+            return response
+        if (request.method, request.url.path) in EXEMPT_METHOD_PATHS:
             return response
         if not (200 <= response.status_code < 300):
             return response

--- a/packages/api/app/routers/auth.py
+++ b/packages/api/app/routers/auth.py
@@ -826,11 +826,12 @@ async def delete_me(
     #   timestamp survive. Operators managing security incidents MUST raise
     #   AUDIT_LOG_RETENTION_DAYS ≥ 365 to fulfil the NIS2 incident evidence
     #   requirement — see docs/privacy.md §7.2 and config.py.
+    # audit_logs is append-only for the application role (M2), so a direct UPDATE
+    # is denied under nis2_app. Pseudonymise through the SECURITY DEFINER
+    # pseudonymize_user_audit_logs() function — it bypasses the REVOKE + RLS and
+    # scrubs user_id / ip_address / user_agent / details on this user's rows.
     await db.execute(
-        text(
-            "UPDATE audit_logs SET user_id = NULL, ip_address = '127.0.0.1', "
-            "user_agent = '[erased]', details = NULL WHERE user_id = :uid"
-        ),
+        text("SELECT pseudonymize_user_audit_logs(:uid)"),
         {"uid": str(user_id)},
     )
 
@@ -850,19 +851,18 @@ async def delete_me(
 
     # 6. Delete lone-tenant orgs and all their tenant-scoped data.
     for org_id in orgs_to_delete:
-        for table in (
-            "findings",
-            "scan_results",
-            "scans",
-            "scan_schedules",
-            "assets",
-            "incidents",
-            "vendors",
-            "business_processes",
-            "api_keys",
-            "memberships",
-            "audit_logs",
-        ):
+        # Scope the session to THIS org so the org-scoped DELETEs below satisfy RLS
+        # under nis2_app — the org being erased may not be the JWT's active org.
+        await _set_session_org_id(db, org_id)
+        # Only the NO-ACTION FK children need an explicit delete before the org.
+        # Every ON DELETE CASCADE child — findings, scans (-> scan_results),
+        # scan_schedules, assets, notification_channels, api_keys, memberships, and
+        # audit_logs — is removed by the organizations delete itself. The RI cascade
+        # is system-enforced, so it bypasses RLS AND the M2 append-only REVOKE on
+        # audit_logs (an explicit DELETE there would be denied). Note: scan_results
+        # has no organization_id column, so the old per-table-by-org delete could
+        # never have worked for it (pre-existing bug).
+        for table in ("business_processes", "incidents", "vendors"):
             await db.execute(
                 text(f"DELETE FROM {table} WHERE organization_id = :oid"),
                 {"oid": str(org_id)},

--- a/packages/api/tests/test_audit_log_erasure.py
+++ b/packages/api/tests/test_audit_log_erasure.py
@@ -87,12 +87,22 @@ class TestCleanupTasksReturnShape:
 class TestPseudonymisationSQL:
     def _erasure_sql(self) -> str:
         import pathlib
-        src = pathlib.Path("app/routers/auth.py").read_text()
-        # Extract the UPDATE audit_logs statement.
+        # The pseudonymisation UPDATE moved into the SECURITY DEFINER
+        # pseudonymize_user_audit_logs() function (database.py) because audit_logs
+        # is append-only for the app role under RLS (M2); auth.py calls it.
+        src = pathlib.Path("app/database.py").read_text()
         start = src.find("UPDATE audit_logs SET")
-        assert start != -1, "Could not find UPDATE audit_logs in auth.py"
-        end = src.find("WHERE user_id = :uid", start)
+        assert start != -1, "Could not find the pseudonymise UPDATE in database.py"
+        end = src.find("WHERE user_id = p_user_id", start)
         return src[start:end]
+
+    def test_auth_calls_pseudonymize_function(self) -> None:
+        import pathlib
+        src = pathlib.Path("app/routers/auth.py").read_text()
+        assert "pseudonymize_user_audit_logs" in src, (
+            "auth.py erasure must call the SECURITY DEFINER pseudonymise function "
+            "(audit_logs is append-only for the app role)"
+        )
 
     def test_user_id_nulled(self) -> None:
         assert "user_id = NULL" in self._erasure_sql()


### PR DESCRIPTION
## H5 — the app now runs under the `nis2_app` least-privilege role

This is the "switch" half of [#140](https://github.com/fabriziosalmi/nis2-public/issues/140): pointing `DATABASE_URL` at the `NOSUPERUSER NOBYPASSRLS` role so RLS is actually enforced (not bypassed by a superuser).

**Validated live:** switched the local stack's `DATABASE_URL`/`DATABASE_URL_SYNC` to `nis2_app`, restarted api + workers, and ran the **full E2E live suite — 53 passed** — plus the GDPR erasure path end-to-end. Four switch-blocking issues surfaced; all fixed here:

1. **API-key auth → 500 on every request.** `get_api_key_org` set `app.current_org_id` *after* the `api_keys` `is_active` / `last_used_at` writes, so those org-scoped UPDATEs matched 0 rows under RLS → `StaleDataError`. Now the GUC is set immediately after the key is resolved, before any write. (Corrects the ordering from #169.)
2. **GDPR erasure → permission denied.** It did a direct `UPDATE audit_logs` (pseudonymise), which #172 made append-only for `nis2_app`. Added a `SECURITY DEFINER pseudonymize_user_audit_logs()` function (EXECUTE revoked from PUBLIC, granted only to `nis2_app`); `auth.py` calls it.
3. **Lone-org erasure cleanup.** It deleted `scan_results` by `organization_id` (the column doesn't exist — a **pre-existing bug**) and `audit_logs` by org (now append-only). Both are `ON DELETE CASCADE` children of `organizations` (`scan_results` via `scans`), so the org delete removes them via the **system-enforced RI cascade** — which bypasses RLS *and* the append-only REVOKE. Now only the NO-ACTION FK tables (`business_processes`, `incidents`, `vendors`) are deleted explicitly, under per-org context, before the org.
4. **Audit middleware on self-deletion.** It tried to log `DELETE /auth/me` after the request deleted the actor (and possibly their org), dangling the `user_id`/`organization_id` FK. Exempted that `(method, path)` — erasure can never be middleware-audited and does its own pseudonymisation.

Everything else already carried RLS context (register sets it before the membership INSERT; `organizations` is not RLS-scoped, so org creation needs none). **Additive / no-op under the current superuser role** — production behaviour is unchanged until an operator flips `DATABASE_URL`.

### Deploy note
The two `SECURITY DEFINER` audit functions + the RLS policies are created by `setup_row_level_security` during a **superuser / migration boot** — operators run that once (as today) before switching the app role to `nis2_app`. The function-creation / REVOKE statements no-op (caught) when the app later boots *as* `nis2_app`.

Unit: 29 audit/RLS + 19 api-key-scope tests green. Remaining on #140: **L1** (scope the RLS predicate to the active org only).
