### PR TITLE
feat(api): scope tenant RLS to the active org only (L1)

### DIFF
--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -212,10 +212,16 @@ async def ensure_schema() -> None:
                 logger.warning("ensure_schema: %s.%s skipped: %s", table, column, exc)
 
 
+# L1: data-table tenant isolation is scoped to the ACTIVE org only. The earlier
+# predicate also OR'd in "any org the current user is a member of", which let a
+# multi-org user's queries read EVERY org they belong to — not just the one they
+# are acting in — an over-permissive defence-in-depth gap. app.current_org_id is
+# set from the JWT's active org (get_db) or the API key's org (get_api_key_org),
+# so this IS the correct tenant boundary. Membership-based access stays ONLY on
+# the `memberships` table (_RLS_MEMBERSHIPS_PREDICATE) so a user can still read
+# their own memberships to enumerate / switch orgs.
 _RLS_PREDICATE = (
-    "(organization_id::text = current_setting('app.current_org_id', true) "
-    "OR (current_setting('app.current_user_id', true) IS NOT NULL AND "
-    "organization_id::text IN (SELECT organization_id::text FROM memberships WHERE user_id::text = current_setting('app.current_user_id', true))))"
+    "(organization_id::text = current_setting('app.current_org_id', true))"
 )
 
 _RLS_MEMBERSHIPS_PREDICATE = (
@@ -285,6 +291,35 @@ async def setup_row_level_security() -> None:
         logger.info(
             "RLS: tenant_isolation policies verified on %d tables.", len(tenant_tables)
         )
+
+    # L1: databases created before the active-org-only predicate still carry the
+    # old membership-OR subquery in their tenant_isolation policy. Recreate any
+    # such policy (detected by 'memberships' appearing in the qual of a
+    # NON-memberships table) with the current _RLS_PREDICATE. Runs as the
+    # superuser/migration role; no-ops (caught) once the app runs as nis2_app —
+    # by then a privileged boot has already applied it.
+    async with engine.connect() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT tablename FROM pg_policies "
+                "WHERE policyname = 'tenant_isolation' "
+                "AND tablename <> 'memberships' AND qual LIKE '%memberships%'"
+            )
+        )
+        stale = [row[0] for row in result]
+    for t in stale:
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(text(f"DROP POLICY tenant_isolation ON {t}"))
+                await conn.execute(
+                    text(
+                        f"CREATE POLICY tenant_isolation ON {t} "
+                        f"USING {_RLS_PREDICATE} WITH CHECK {_RLS_PREDICATE}"
+                    )
+                )
+            logger.info("L1: recreated tenant_isolation on %s (active-org-only).", t)
+        except Exception as exc:
+            logger.warning("L1: could not recreate tenant_isolation on %s: %s", t, exc)
 
     # api_keys is a BOOTSTRAP table: get_api_key_org looks a key up BY key_hash to
     # DISCOVER its org, so that query runs with no app.current_org_id set — and the

--- a/packages/api/app/middleware/audit.py
+++ b/packages/api/app/middleware/audit.py
@@ -74,6 +74,18 @@ async def log_action(
             ip_address = request.client.host
         user_agent = request.headers.get("user-agent")
 
+    # L1: the audit row's organization_id must satisfy the active-org-only RLS
+    # WITH CHECK. A handler may legitimately log an action for an org OTHER than
+    # the caller's currently-active one (creating an org, switching org), so scope
+    # the session to the row's org here. Transaction-scoped (is_local=true) on the
+    # request session; these handlers audit as their last write, so the context
+    # switch has no further effect within the request.
+    if IS_POSTGRES:
+        await db.execute(
+            text("SELECT set_config('app.current_org_id', :v, true)"),
+            {"v": str(org_id)},
+        )
+
     audit_entry = AuditLog(
         organization_id=org_id,
         user_id=user_id,

--- a/packages/api/app/routers/organizations.py
+++ b/packages/api/app/routers/organizations.py
@@ -103,6 +103,10 @@ async def create_organization(
             detail="An organization with a conflicting name was just created; please retry.",
         )
 
+    # The admin membership INSERT passes the memberships RLS WITH CHECK via its
+    # user_id clause (the founder is current_user); the audit row below is scoped
+    # to the new org by log_action itself. So no explicit context switch is needed
+    # here — organizations is not RLS-scoped either.
     membership = Membership(
         user_id=current_user.id,
         organization_id=org.id,

--- a/packages/api/tests/test_asset_update_validation.py
+++ b/packages/api/tests/test_asset_update_validation.py
@@ -42,7 +42,9 @@ class FakeDbSession:
             return FakeAsset()
         return None
 
-    async def execute(self, statement):
+    async def execute(self, statement, *args, **kwargs):
+        # Match AsyncSession.execute, which accepts bind `parameters` — log_action
+        # issues `execute(text(...), {params})` to set the RLS org context.
         return FakeResult()
 
     def add(self, instance):

--- a/packages/api/tests/test_integration.py
+++ b/packages/api/tests/test_integration.py
@@ -225,9 +225,14 @@ class TestRowLevelSecurity:
             "disabled."
         )
 
-    def test_user_id_membership_access_path_works(self, fresh_client):
-        """A user must still see all rows belonging to their organizations when
-        app.current_user_id is set to their user ID."""
+    def test_user_id_alone_does_not_grant_data_access(self, fresh_client):
+        """L1: data tables are scoped to the ACTIVE org (app.current_org_id) only.
+
+        Setting just app.current_user_id (no org context) must NOT expose data
+        rows — the old "any org the user is a member of" OR was removed from the
+        data-table predicate. That user_id access path now lives ONLY on the
+        `memberships` table, so the user can still read their own memberships to
+        enumerate / switch orgs."""
         from app.models.user import User
         _register_org(fresh_client, "user-access")
         fresh_client.post(
@@ -244,15 +249,30 @@ class TestRowLevelSecurity:
             async with async_session_factory() as session:
                 user_res = await session.execute(select(User).limit(1))
                 user = user_res.scalar_one()
+                # Set ONLY the user id — no app.current_org_id.
                 await session.execute(
                     text("SELECT set_config('app.current_user_id', :v, true)"),
                     {"v": str(user.id)},
                 )
-                result = await session.execute(text("SELECT COUNT(*) FROM assets"))
-                return result.scalar()
+                assets = (
+                    await session.execute(text("SELECT COUNT(*) FROM assets"))
+                ).scalar()
+                memberships = (
+                    await session.execute(text("SELECT COUNT(*) FROM memberships"))
+                ).scalar()
+                return assets, memberships
 
-        count = _async_run(_query())
-        assert count >= 1
+        assets, memberships = _async_run(_query())
+        # L1: data tables are invisible without an active-org context.
+        assert assets == 0, (
+            "L1 regression: a data table was visible via app.current_user_id "
+            "alone — the active-org-only predicate is not in effect"
+        )
+        # The memberships table keeps the user_id access path.
+        assert memberships >= 1, (
+            "memberships must stay visible via the user_id clause so a user can "
+            "enumerate their orgs"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**L1** (draconian review). The data-table `tenant_isolation` predicate OR'd in *"any org the current user is a member of"*, so a multi-org user's queries could read **every** org they belong to — not just the one they're acting in. Now scoped to `app.current_org_id` only (set from the JWT's active org via `get_db`, or the API key's org via `get_api_key_org`). The membership-based clause stays **only** on the `memberships` table so users can still enumerate / switch orgs.

- `_RLS_PREDICATE` → active-org-only. `setup_row_level_security` recreates any existing `tenant_isolation` policy still carrying the old membership subquery (detected by `memberships` in a non-memberships table's qual). Superuser/migration boot applies it; no-ops (caught) under `nis2_app`.
- `log_action` scopes the session to the audit row's org before inserting, so a handler can audit an action for an org other than the caller's active one (create-org, switch-org) without tripping the now-strict WITH CHECK.

**Validated live under `nis2_app`:** a user who is a member of orgs A and B, active in A, sees **0** of B's rows (the old predicate would have shown them); active in B, sees them. Full **E2E 53/53** (incl. create-org + switch-org), erasure 204, 29 RLS/audit unit tests green. Additive / no-op under the current superuser role.

Completes the remaining chunk on #140.