### PR TITLE
fix(web): add aria-labels to icon-only buttons (L6 a11y)

### DIFF
--- a/packages/web/src/app/dashboard/scans/[id]/page.tsx
+++ b/packages/web/src/app/dashboard/scans/[id]/page.tsx
@@ -171,7 +171,7 @@ export default function ScanDetailPage({ params }: { params: Promise<{ id: strin
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/dashboard/scans"><ArrowLeft className="h-4 w-4" /></Link>
+          <Link href="/dashboard/scans" aria-label="Back to scans"><ArrowLeft className="h-4 w-4" /></Link>
         </Button>
         <div className="flex-1">
           <div className="flex flex-wrap items-center gap-3">

--- a/packages/web/src/app/dashboard/scans/new/page.tsx
+++ b/packages/web/src/app/dashboard/scans/new/page.tsx
@@ -199,7 +199,7 @@ export default function NewScanPage() {
     <div className="space-y-6 max-w-3xl">
       <div className="flex items-center gap-4">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/dashboard/scans">
+          <Link href="/dashboard/scans" aria-label="Back to scans">
             <ArrowLeft className="h-4 w-4" />
           </Link>
         </Button>

--- a/packages/web/src/app/dashboard/scans/schedules/page.tsx
+++ b/packages/web/src/app/dashboard/scans/schedules/page.tsx
@@ -298,15 +298,15 @@ export default function SchedulesPage() {
                     <TableCell className="text-right">
                       <div className="flex gap-1 justify-end">
                         <Button variant="ghost" size="icon" className="h-8 w-8"
-                          onClick={() => triggerNow(s.id)} disabled={triggering === s.id}>
+                          onClick={() => triggerNow(s.id)} disabled={triggering === s.id} aria-label="Run schedule now">
                           {triggering === s.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
                         </Button>
                         <Button variant="ghost" size="icon" className="h-8 w-8"
-                          onClick={() => toggleSchedule(s.id, s.is_active)}>
+                          onClick={() => toggleSchedule(s.id, s.is_active)} aria-label="Pause or resume schedule">
                           {s.is_active ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4 text-green-600" />}
                         </Button>
                         <Button variant="ghost" size="icon" className="h-8 w-8 text-destructive"
-                          onClick={() => deleteSchedule(s.id)}>
+                          onClick={() => deleteSchedule(s.id)} aria-label="Delete schedule">
                           <Trash2 className="h-4 w-4" />
                         </Button>
                       </div>

--- a/packages/web/src/app/dashboard/settings/api-keys/page.tsx
+++ b/packages/web/src/app/dashboard/settings/api-keys/page.tsx
@@ -105,7 +105,7 @@ export default function ApiKeysPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-4">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/dashboard/settings">
+          <Link href="/dashboard/settings" aria-label="Back to settings">
             <ArrowLeft className="h-4 w-4" />
           </Link>
         </Button>
@@ -137,7 +137,7 @@ export default function ApiKeysPage() {
                   <div className="flex items-center gap-2 rounded-lg bg-muted p-3">
                     <Key className="h-4 w-4 text-muted-foreground shrink-0" />
                     <code className="flex-1 text-sm font-mono break-all">{newKey}</code>
-                    <Button variant="ghost" size="icon" onClick={handleCopy}>
+                    <Button variant="ghost" size="icon" onClick={handleCopy} aria-label="Copy key to clipboard">
                       <Copy className="h-4 w-4" />
                     </Button>
                   </div>
@@ -247,7 +247,7 @@ export default function ApiKeysPage() {
                             </Button>
                           </div>
                         ) : (
-                          <Button variant="ghost" size="icon" onClick={() => setRevokeId(key.id)}>
+                          <Button variant="ghost" size="icon" onClick={() => setRevokeId(key.id)} aria-label="Delete API key">
                             <Trash2 className="h-4 w-4 text-muted-foreground" />
                           </Button>
                         )

--- a/packages/web/src/app/dashboard/settings/notifications/page.tsx
+++ b/packages/web/src/app/dashboard/settings/notifications/page.tsx
@@ -196,10 +196,10 @@ export default function NotificationsPage() {
                   </div>
                 </div>
                 <div className="flex gap-1">
-                  <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => toast.info(t("testSent"))}>
+                  <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => toast.info(t("testSent"))} aria-label="Send test notification">
                     <TestTube className="h-4 w-4" />
                   </Button>
-                  <Button variant="ghost" size="icon" className="h-8 w-8 text-destructive" onClick={() => removeChannel(ch.id)}>
+                  <Button variant="ghost" size="icon" className="h-8 w-8 text-destructive" onClick={() => removeChannel(ch.id)} aria-label="Delete channel">
                     <Trash2 className="h-4 w-4" />
                   </Button>
                 </div>

--- a/packages/web/src/app/dashboard/settings/team/page.tsx
+++ b/packages/web/src/app/dashboard/settings/team/page.tsx
@@ -191,7 +191,7 @@ export default function TeamPage() {
     <div className="space-y-6">
       <div className="flex items-center gap-4">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/dashboard/settings">
+          <Link href="/dashboard/settings" aria-label="Back to settings">
             <ArrowLeft className="h-4 w-4" />
           </Link>
         </Button>
@@ -391,7 +391,7 @@ export default function TeamPage() {
                         {!isSelf && (
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <Button variant="ghost" size="icon">
+                              <Button variant="ghost" size="icon" aria-label="Member options">
                                 <MoreHorizontal className="h-4 w-4" />
                               </Button>
                             </DropdownMenuTrigger>

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -222,7 +222,7 @@ function SiteHeader() {
           <div className="fixed inset-y-0 right-0 z-50 w-full max-w-xs border-l bg-background p-6 shadow-lg sm:max-w-sm">
             <div className="flex items-center justify-between mb-8">
               <span className="font-semibold tracking-tight">NIS2 Platform</span>
-              <Button variant="ghost" size="icon" onClick={() => setMobileOpen(false)}>
+              <Button variant="ghost" size="icon" onClick={() => setMobileOpen(false)} aria-label="Close menu">
                 <X className="h-5 w-5" />
               </Button>
             </div>


### PR DESCRIPTION
**L6** (draconian review — UI states + a11y). An audit of `packages/web/src` found the app is in good shape — images have alt text, form inputs have labels, list pages have loading/empty/error states, dialogs use Radix primitives (focus trap + `aria-modal`), and clickable elements are semantic buttons with keyboard handlers. The **one** significant gap: **13 icon-only buttons with no accessible name**, invisible to screen readers.

Added an `aria-label` to each: back-nav (×4), copy key, delete key/channel/schedule, send test notification, run/pause schedule, member-options dropdown, close mobile menu. For `asChild` buttons the label lands on the inner `<Link>` (the rendered anchor). `next build` compiles clean.

Follow-up idea (not done): an ESLint rule flagging `size="icon"` Buttons without `aria-label`/`title` to prevent regressions.