### PR TITLE
fix(web): allow dev-stack origins so HMR connects (allowedDevOrigins)

### DIFF
--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -4,6 +4,14 @@ import path from 'node:path'
 
 const config: NextConfig = {
   output: 'standalone',
+  // Dev-only: Next 15.2+/16 blocks cross-origin requests to internal dev
+  // resources (notably the /_next/webpack-hmr WebSocket) unless the requesting
+  // origin is allow-listed. The docker dev stack is reached at 127.0.0.1:8077 /
+  // localhost:8077 through the port-forward, which Next treats as cross-origin —
+  // so HMR logged "Blocked cross-origin request to Next.js dev resource" and the
+  // hot-reload socket never connected. Allow-listing the dev hosts restores it.
+  // Ignored in production builds.
+  allowedDevOrigins: ['127.0.0.1', 'localhost'],
   // The repo root has its own package-lock.json (for the VitePress docs
   // build) AND this package has its own. Without pinning the trace root
   // Next 15 prints "We detected multiple lockfiles..." and infers the


### PR DESCRIPTION
The browser console showed `WebSocket connection to ws://127.0.0.1:8077/_next/webpack-hmr failed` on the docker dev stack. Root cause (from the dev log): **`Blocked cross-origin request to Next.js dev resource /_next/webpack-hmr from "127.0.0.1"`** — Next 15.2+/16 gates cross-origin access to internal dev resources, and the stack is reached at `127.0.0.1:8077`/`localhost:8077` through the Docker port-forward.

Fix: `allowedDevOrigins: ['127.0.0.1', 'localhost']` in `next.config.ts` (dev-only, ignored in prod). Verified after restart: **0** `Blocked cross-origin` warnings, the HMR WS handshake is accepted, prod build still compiles clean. Supersedes the earlier "cosmetic Docker HMR quirk" note — it was fixable.