### PR TITLE
fix(web): add autocomplete attributes to auth form inputs

### DIFF
--- a/packages/web/src/app/(auth)/forgot-password/page.tsx
+++ b/packages/web/src/app/(auth)/forgot-password/page.tsx
@@ -115,6 +115,7 @@ export default function ForgotPasswordPage() {
               id="email"
               type="email"
               placeholder={t("auth.emailPlaceholder")}
+              autoComplete="username"
               autoFocus
               {...register("email")}
             />

--- a/packages/web/src/app/(auth)/login/page.tsx
+++ b/packages/web/src/app/(auth)/login/page.tsx
@@ -100,6 +100,7 @@ export default function LoginPage() {
             <Input
               id="email"
               type="email"
+              autoComplete="username"
               placeholder={t("auth.emailPlaceholder")}
               aria-invalid={!!errors.email}
               aria-describedby={errors.email ? "email-error" : undefined}

--- a/packages/web/src/app/(auth)/register/page.tsx
+++ b/packages/web/src/app/(auth)/register/page.tsx
@@ -81,6 +81,7 @@ export default function RegisterPage() {
             <Input
               id="full_name"
               placeholder={t("auth.fullNamePlaceholder")}
+              autoComplete="name"
               aria-invalid={!!errors.full_name}
               aria-describedby={errors.full_name ? "full_name-error" : undefined}
               {...register("full_name")}
@@ -97,6 +98,7 @@ export default function RegisterPage() {
               id="email"
               type="email"
               placeholder={t("auth.emailPlaceholder")}
+              autoComplete="username"
               aria-invalid={!!errors.email}
               aria-describedby={errors.email ? "email-error" : undefined}
               {...register("email")}

--- a/packages/web/src/app/(auth)/reset-password/page.tsx
+++ b/packages/web/src/app/(auth)/reset-password/page.tsx
@@ -155,6 +155,7 @@ function ResetPasswordInner() {
               id="new_password"
               type="password"
               placeholder={t("auth.passwordMin8")}
+              autoComplete="new-password"
               autoFocus
               {...register("new_password")}
             />
@@ -167,6 +168,7 @@ function ResetPasswordInner() {
             <Input
               id="confirm_password"
               type="password"
+              autoComplete="new-password"
               {...register("confirm_password")}
             />
             {errors.confirm_password && (

--- a/packages/web/src/app/dashboard/settings/profile/page.tsx
+++ b/packages/web/src/app/dashboard/settings/profile/page.tsx
@@ -144,7 +144,7 @@ export default function ProfileSettingsPage() {
 
             <div className="space-y-2">
               <Label htmlFor="full_name">{t("fullName")}</Label>
-              <Input id="full_name" {...profileForm.register("full_name")} />
+              <Input id="full_name" autoComplete="name" {...profileForm.register("full_name")} />
               {profileForm.formState.errors.full_name && (
                 <p className="text-xs text-destructive">{profileForm.formState.errors.full_name.message}</p>
               )}


### PR DESCRIPTION
Browser console warned `Input elements should have autocomplete attributes (suggested: "username")` on the login email, and password managers can't autofill reliably without them. Added `autoComplete` across the auth forms: login/register/forgot email → `username`; register/profile full name → `name`; reset-password new + confirm → `new-password`. (Login/register/profile password fields already had the right values.) `next build` compiles clean.