### PR TITLE
fix(web): upgrade @hookform/resolvers to v5 for Zod 4 (validation no longer crashes)

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "@nis2/web",
-  "version": "2.5.13",
+  "version": "2.5.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nis2/web",
-      "version": "2.5.13",
+      "version": "2.5.16",
       "dependencies": {
-        "@hookform/resolvers": "^3.9.1",
+        "@hookform/resolvers": "^5.4.0",
         "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.6",
@@ -151,12 +151,15 @@
       }
     },
     "node_modules/@hookform/resolvers": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
-      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
       "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
       "peerDependencies": {
-        "react-hook-form": "^7.0.0"
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@img/colour": {
@@ -2806,6 +2809,12 @@
       "version": "1.21.5",
       "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
       "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/core-darwin-arm64": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@hookform/resolvers": "^3.9.1",
+    "@hookform/resolvers": "^5.4.0",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.6",

--- a/packages/web/src/app/dashboard/settings/scan-defaults/page.tsx
+++ b/packages/web/src/app/dashboard/settings/scan-defaults/page.tsx
@@ -58,7 +58,11 @@ export default function ScanDefaultsPage() {
   const [loadError, setLoadError] = useState<string | null>(null)
   const [loadingInitial, setLoadingInitial] = useState(true)
 
-  const { register, handleSubmit, reset, formState: { errors, isDirty }, watch, setValue } = useForm<ScanDefaultsForm>({
+  // @hookform/resolvers v5 types the resolver as Resolver<input, ctx, output>.
+  // This schema uses z.coerce.number(), so its input type (pre-coerce) differs
+  // from its output type (number). Type the form with both so RHF matches the
+  // resolver; coercion still runs at validation time.
+  const { register, handleSubmit, reset, formState: { errors, isDirty }, watch, setValue } = useForm<z.input<typeof scanDefaultsSchema>, unknown, ScanDefaultsForm>({
     resolver: zodResolver(scanDefaultsSchema),
     defaultValues: defaults,
   })


### PR DESCRIPTION
**Bug:** an invalid form field surfaced as a Next.js runtime **`ZodError`** overlay instead of an inline validation message (reported on a password-min-8 field).

**Root cause:** the app uses **Zod 4** (`zod ^4.4.3`) but `@hookform/resolvers` resolved to **3.10.0**, whose `/zod` entry only supports Zod 3. Reproduced in isolation: `zodResolver(zod4Schema)` on invalid input **threw** a `ZodError` instead of returning field errors → react-hook-form never caught it → Next overlay.

**Fix:** upgraded `@hookform/resolvers` to **^5.4.0** (Zod-4-native). Same repro now returns `{message:"auth.passwordMin8", type:"too_small"}` → react-hook-form shows it inline. Typed the one `z.coerce` form (scan-defaults) as `useForm<input, ctx, output>` to match v5's stricter `Resolver` typing (coercion still runs at validation). `next build` + type-check pass; only form using coerce was scan-defaults.