### PR TITLE
Remove Google Fonts third-party egress from the scanner report

### DIFF
--- a/packages/scanner/nis2scan/cli.py
+++ b/packages/scanner/nis2scan/cli.py
@@ -358,9 +358,6 @@ def generate_index_page(directory):
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NIS2 Compliance Reports</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <style>
         :root {{
             --primary: #0f172a;
@@ -509,7 +506,7 @@ def generate_index_page(directory):
         }}
 
         .scan-id {{
-            font-family: 'JetBrains Mono', monospace;
+            font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
             font-size: 0.65rem;
             color: var(--text-muted);
             background: #f8fafc;

--- a/packages/scanner/templates/report.css
+++ b/packages/scanner/templates/report.css
@@ -223,7 +223,7 @@ tr:hover {
 }
 
 .reference {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     font-size: 0.8rem;
     color: var(--text-muted);
     background: #f1f5f9;
@@ -317,7 +317,7 @@ tr:hover {
 }
 
 .tech-detail {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     font-size: 0.8rem;
     color: #475569;
     background: #f8fafc;

--- a/packages/scanner/templates/report_template.html
+++ b/packages/scanner/templates/report_template.html
@@ -5,12 +5,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NIS2 Compliance Report</title>
-    <!-- Google Fonts: Inter -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;800&family=JetBrains+Mono:wght@400;500&display=swap"
-        rel="stylesheet">
 
     <style>
         /* Injected CSS */


### PR DESCRIPTION
Both copies of the compliance report loaded Inter + JetBrains Mono from `fonts.googleapis.com`, so opening a report sent the reader's IP to Google (the privacy issue behind the LG München ruling) and added render-blocking third-party connections — in a **NIS2 compliance report**, which is its own kind of irony.

Inter's stack already fell back to `system-ui, -apple-system`; **JetBrains Mono fell back to a bare `monospace`**, so this widens the mono stack rather than leaving it to the browser default:
```css
font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
```
Both font names stay first in their stacks, so locally-installed copies still win with **zero network requests**.

Applied to all three parts of that surface: `templates/report_template.html` (flagged), `templates/report.css` (the injected CSS holding the stacks), and the duplicate template inlined in `nis2scan/cli.py` — which would otherwise have kept emitting the links.

**Out of scope, flagging only**: `packages/web/src/middleware.ts` still allows `fonts.googleapis.com` / `fonts.gstatic.com` in the web app's CSP (`style-src` / `font-src`), so the Next.js app is a second surface with the same egress. I left it alone — tightening that CSP means also removing the fonts from the web app itself, which is a bigger change than this one.

Found by the AGSSH AG-PRV-03 surface-egress check.