### PR TITLE
chore(release): 2.6.5 — security: docs-build vite/postcss CVE fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2.6.5] - 2026-08-03
+
+### 🛡️ Security — docs-build dependency CVE fixes
+
+Closes the remaining Dependabot alerts, all in the **root `package-lock.json`**
+(the VitePress documentation build — dev/build-time only, not the app runtime):
+
+- **`vite` 6.4.2 → 6.4.3** — GHSA-fx2h-pf6j-xcff (HIGH), GHSA-v6wh-96g9-6wx3
+  (MEDIUM).
+- **`postcss` → 8.5.25** (override raised to `^8.5.18`) — GHSA-r28c-9q8g-f849
+  (path traversal). Supersedes #213.
+
+`npm audit --audit-level=high` (root) → 0 vulnerabilities.
+
 ## [2.6.4] - 2026-08-03
 
 ### 🔧 Dependency maintenance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nis2-public-docs",
-  "version": "2.5.13",
+  "version": "2.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nis2-public-docs",
-      "version": "2.5.13",
+      "version": "2.6.4",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.4",
@@ -1595,6 +1595,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
@@ -2762,9 +2826,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2820,9 +2884,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -2840,7 +2904,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3193,9 +3257,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nis2-public-docs",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "private": true,
   "description": "VitePress documentation build for the NIS2 Continuous Posture Management Platform.",
   "scripts": {
@@ -35,7 +35,7 @@
     "rollup": "^4.59.0",
     "preact": "^10.28.2",
     "esbuild": "^0.25.0",
-    "vite": "^6.4.2",
-    "postcss": "^8.5.10"
+    "vite": "^6.4.3",
+    "postcss": "^8.5.18"
   }
 }

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nis2-api"
-version = "2.6.4"
+version = "2.6.5"
 description = "NIS2 Compliance Platform API"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/scanner/pyproject.toml
+++ b/packages/scanner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nis2scan"
-version = "2.6.4"
+version = "2.6.5"
 description = "NIS2 Directive compliance scanner engine"
 requires-python = ">=3.10"
 dependencies = [

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nis2/web",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes the remaining Dependabot alerts, all in the **root `package-lock.json`** (the VitePress documentation build — dev/build-time only, not the app runtime).

- **`vite` 6.4.2 → 6.4.3** — GHSA-fx2h-pf6j-xcff (HIGH), GHSA-v6wh-96g9-6wx3 (MEDIUM)
- **`postcss` → 8.5.25** (override raised to `^8.5.18`) — GHSA-r28c-9q8g-f849 (path traversal)

Fix applied by raising the root `overrides` and refreshing the lockfile.

**Verification:** `npm audit --audit-level=high` (root) → **0 vulnerabilities**.

Supersedes #213. Version bumped to **2.6.5**.

After this, the only open PRs left are the three GitHub Actions majors (#204/#206/#209), postponed by decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)