### PR TITLE
fix(security): 2.6.10 — pin nanoid >=3.3.17 (CVE-2026-67213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2.6.10] - 2026-08-08
+
+### 🛡️ Security — nanoid HIGH CVE
+
+Follow-up to the 2.6.9 web roll-up: a newly-disclosed HIGH advisory surfaced in
+a transitive dependency (flagged by `npm audit` / `trivy fs`).
+
+- **`nanoid` → 3.3.18** via a new `overrides` pin `^3.3.17` — CVE-2026-67213 /
+  GHSA-2v37-7h3g-55p8 (infinite loop in `customAlphabet` when size is 0). nanoid
+  is pulled transitively (postcss / next); the override forces it up without
+  touching the direct dependencies.
+
+`npm audit --audit-level=high` → 0 vulnerabilities.
+
 ## [2.6.9] - 2026-08-08
 
 ### 🔧 Dependency maintenance (web roll-up)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nis2-public-docs",
-  "version": "2.6.9",
+  "version": "2.6.10",
   "private": true,
   "description": "VitePress documentation build for the NIS2 Continuous Posture Management Platform.",
   "scripts": {

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nis2-api"
-version = "2.6.9"
+version = "2.6.10"
 description = "NIS2 Compliance Platform API"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/scanner/pyproject.toml
+++ b/packages/scanner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nis2scan"
-version = "2.6.9"
+version = "2.6.10"
 description = "NIS2 Directive compliance scanner engine"
 requires-python = ">=3.10"
 dependencies = [

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nis2/web",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nis2/web",
-      "version": "2.6.8",
+      "version": "2.6.9",
       "dependencies": {
         "@hookform/resolvers": "^5.5.7",
         "@radix-ui/react-avatar": "^1.2.6",
@@ -4418,9 +4418,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nis2/web",
-  "version": "2.6.9",
+  "version": "2.6.10",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -55,6 +55,7 @@
     "lodash-es": "^4.18.1",
     "postcss": "^8.5.18",
     "sharp": "^0.35.0",
-    "@swc/helpers": "^0.5.17"
+    "@swc/helpers": "^0.5.17",
+    "nanoid": "^3.3.17"
   }
 }


### PR DESCRIPTION
Follow-up to the 2.6.9 web dependency roll-up. Refreshing the lockfile surfaced a **newly-disclosed HIGH advisory** in a transitive dependency (flagged by `npm audit` + `trivy fs`, which is why 2.6.9's security jobs went red).

- **`nanoid` → 3.3.18** via a new `overrides` pin `^3.3.17` — **CVE-2026-67213 / GHSA-2v37-7h3g-55p8** (infinite loop in `customAlphabet` when size is 0).
- nanoid is pulled transitively (postcss / next), so the fix is an `overrides` pin — no direct-dependency change.

**Verification:** `npm audit --audit-level=high` → **0 vulnerabilities**.

> Note: 2.6.9 (the web roll-up incl. recharts 3) merged with these security checks red; this patch closes them. No separate v2.6.9 GitHub release was cut — the roll-up ships to users as part of v2.6.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)