### PR TITLE
seo(docs): genera la sitemap.xml (VitePress)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -32,6 +32,9 @@ export default defineConfig({
     title: "NIS2 Platform",
     description: "Open-source GRC platform for NIS2 Directive (EU 2022/2555). Governance framework, technical validation engine, incident response, and supply chain risk management.",
     base: "/nis2-public/",
+    // The hostname carries the base path on purpose: VitePress joins it with each
+    // page's route, so without it every URL in the sitemap would point at a 404.
+    sitemap: { hostname: 'https://fabriziosalmi.github.io/nis2-public/' },
     ignoreDeadLinks: true,
     appearance: 'dark',
     lastUpdated: true,


### PR DESCRIPTION
VitePress sa generare la sitemap da solo: serve solo `sitemap.hostname`.

**L'hostname deve portarsi dietro il base path.** VitePress lo unisce alla rotta di ogni pagina, quindi senza di esso ogni URL della sitemap punterebbe a un 404 ([docs](https://vitepress.dev/guide/sitemap-generation#options)).

**Verificato costruendo davvero il sito**, non solo leggendo la config: **30 URL** generati, tutti con il base corretto. Primo URL della sitemap: `https://fabriziosalmi.github.io/nis2-public/ISSUE-pdf-report-refinement.html`

**Perché conta qui:** la home linka **11** pagine, il sito ne ha **30**. La differenza Google la trova solo per caso.

Tre righe in `docs/.vitepress/config.mts`, nessun file nuovo, nessuna dipendenza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
